### PR TITLE
48 add support for h5 input format

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -17,15 +17,15 @@
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+\\.(h5ad|rds|RDS|csv)$",
-                "errorMessage": "Input file must be a .h5ad, .rds or .csv file."
+                "pattern": "^\\S+\\.(h5ad|h5|rds|RDS|csv)$",
+                "errorMessage": "Input file must be a .h5ad, .h5, .rds or .csv or file."
             },
             "raw": {
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+\\.(h5ad|rds|RDS|csv)$",
-                "errorMessage": "Input file must be a .h5ad, .rds or .csv file."
+                "pattern": "^\\S+\\.(h5ad|h5|rds|RDS|csv)$",
+                "errorMessage": "Input file must be a .h5ad, .h5, .rds or .csv or file."
             },
             "batch_col": {
                 "type": "string",

--- a/modules/local/scanpy/readh5/main.nf
+++ b/modules/local/scanpy/readh5/main.nf
@@ -4,8 +4,8 @@ process SCANPY_READH5 {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://community.wave.seqera.io/library/anndata:0.10.7--e9840a94592528c8':
-        'community.wave.seqera.io/library/anndata:0.10.7--336c6c1921a0632b' }"
+        'oras://community.wave.seqera.io/library/scanpy:1.10.1--ea08051addf267ac':
+        'community.wave.seqera.io/library/scanpy:1.10.1--0c8c97148fc05558' }"
 
     input:
     tuple val(meta), path(h5)

--- a/modules/local/scanpy/readh5/templates/readh5.py
+++ b/modules/local/scanpy/readh5/templates/readh5.py
@@ -23,7 +23,6 @@ def format_yaml_like(data: dict, indent: int = 0) -> str:
             yaml_str += f"{spaces}{key}: {value}\\n"
     return yaml_str
 
-df = pd.read_csv("${csv}", index_col=0)
 adata = sc.read_10x_h5("${h5}")
 adata.write_h5ad("${prefix}.h5ad")
 


### PR DESCRIPTION
I just tested and fixed h5 reading.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the nf-core/scdownstream _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
