### PR TITLE
Allow skip of ambient_removal by introducing method 'none'

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -51,7 +51,7 @@
                 "ambient_removal": {
                     "type": "string",
                     "default": "decontx",
-                    "enum": ["decontx", "cellbender", "soupx", "scar"],
+                    "enum": ["none", "decontx", "cellbender", "soupx", "scar"],
                     "description": "Specify the tool to use for ambient RNA removal"
                 },
                 "doublet_detection": {

--- a/subworkflows/local/ambient_rna_removal.nf
+++ b/subworkflows/local/ambient_rna_removal.nf
@@ -12,13 +12,15 @@ workflow AMBIENT_RNA_REMOVAL {
     main:
     ch_versions = Channel.empty()
 
-    if (params.ambient_removal == 'decontx') {
+    if (params.ambient_removal == 'none') {
+        println "AMBIENT_RNA_REMOVAL: Not performed since 'none' selected."
+    }
+    else if (params.ambient_removal == 'decontx') {
         CELDA_DECONTX(ch_h5ad)
         ch_h5ad = CELDA_DECONTX.out.h5ad
         ch_versions = ch_versions.mix(CELDA_DECONTX.out.versions)
     }
-
-    if (params.ambient_removal == 'cellbender') {
+    else if (params.ambient_removal == 'cellbender') {
         CELLBENDER_REMOVEBACKGROUND(ch_h5ad)
         ch_versions = ch_versions.mix(CELLBENDER_REMOVEBACKGROUND.out.versions)
 
@@ -26,21 +28,22 @@ workflow AMBIENT_RNA_REMOVAL {
         ch_h5ad = CELLBENDER_MERGE.out.h5ad
         ch_versions = ch_versions.mix(CELLBENDER_MERGE.out.versions)
     }
-
-    if (params.ambient_removal == 'soupx') {
+    else if (params.ambient_removal == 'soupx') {
         SOUPX(ch_h5ad.map{ meta, h5ad -> [meta.id, meta, h5ad]}
             .join(ch_raw.map{ meta, h5ad -> [meta.id, h5ad]}, failOnMismatch: true)
             .map{ id, meta, h5ad, raw -> [meta, h5ad, raw] })
         ch_h5ad = SOUPX.out.h5ad
         ch_versions = ch_versions.mix(SOUPX.out.versions)
     }
-
-    if (params.ambient_removal == 'scar') {
+    else if (params.ambient_removal == 'scar') {
         SCVITOOLS_SCAR(ch_h5ad.map{ meta, h5ad -> [meta.id, meta, h5ad]}
             .join(ch_raw.map{ meta, h5ad -> [meta.id, h5ad]}, failOnMismatch: true)
             .map{ id, meta, h5ad, raw -> [meta, h5ad, raw] })
         ch_h5ad = SCVITOOLS_SCAR.out.h5ad
         ch_versions = SCVITOOLS_SCAR.out.versions
+    }
+    else {
+        error "AMBIENT_RNA_REMOVAL: Unexpected value of param 'params.ambient_removal': '${params.ambient_removal}'."
     }
 
     emit:


### PR DESCRIPTION
The param.ambient_removal is used within work flow AMBIENT_RNA_REMOVAL (see subworkflows/local/ambient_rna_removal.nf) to skip the invocation of that external tool.

This is meant as a quick fix when reads need to be filtered to perform that removal since these removal methods are sensitive to cells with low quality data, but only unfiltered data are available.

---

The idea for this PR was by @nictru in https://github.com/nf-core/scdownstream/issues/51#issuecomment-2205916932 . This was meant to help overcome the situation in which the nf-core/scrnaseq default settings only generate alevin data that is unfiltered and the ambient removal routines cannot cope with that data, but the routines that would preform filtering within scdownstream are only invoked afterwards.

I was not sure about the "else"s that I introduced, I just wanted to return a message in case the schema and this "switch" statement are not in sync.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
Would need some directions.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
