### PR TITLE
docs: describing sources of input and interaction with workflow parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ Steps marked with the boat icon are not yet implemented. For the other steps, th
    1. [Leiden clustering](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.leiden.html)
    2. [UMAP](https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.umap.html)
 
+### Compatibility
+
+These algorithms are sensitive at times. When sequencing depths are low, too many 0s for a particular gene or cell are likely to cause runtime errors.
+That is why cells and genes can be filtered from the input that are not showing a minimal abundance. But some algorithms also explicitly demand the
+unfiltered "raw" files.
+
+The nf-core/scrnaseq pipeline offers a series of aligners, see https://nf-co.re/scrnaseq/2.7.0/parameters/ . The default --aligner "alevin" only provides raw data.
+This may cause such problems with an early step in scdownstream, the removal of ambient RNA, for which the default method "decontX" expects filtered input.
+
+The descriptions of the usage and parameters provide further guidance.
+With some confidence, over time the default parameters for the nf-core scrnaseq and scdownstream will strive for maximal robustness.
+
 ## Usage
 
 > [!NOTE]


### PR DESCRIPTION
These changes to the documentation summarize much of what I learned over the last few days.

A paragraph that I consider missing is an explanation of when the min.genes etc filters are to be applied. Some ambient removal tools do not want anything filtered, so these cannot be applied early. But other tools _do_ want filtered output and then these are to be run if the data provided is too sparse for the statistics being applied.

My proposal is an optional invocation of a second, then early, filtering. That would then be partially (and conditionally) redundant with what scrnaseq provides, though.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scdownstream/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scdownstream _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
