### PR TITLE
Fix doublet filtering out non-doublets cells

### DIFF
--- a/modules/local/doublet_detection/doublet_removal/templates/doublet_removal.py
+++ b/modules/local/doublet_detection/doublet_removal/templates/doublet_removal.py
@@ -41,7 +41,7 @@ def load(path: str) -> pd.DataFrame:
 predictions = pd.concat([load(f) for f in "${predictions}".split()], axis=1)
 mask = predictions.sum(axis=1) >= threshold
 
-adata = adata[mask, :]
+adata = adata[~mask, :]
 adata.write_h5ad(f"{prefix}.h5ad")
 
 # Versions


### PR DESCRIPTION
The use of the mask was inverted. The adata[mask, :] was keeping the cells that are being predicted as doublets and filtering out the non-doublets cells

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).