### PR TITLE
fix merge.py

### DIFF
--- a/modules/local/adata/merge/templates/merge.py
+++ b/modules/local/adata/merge/templates/merge.py
@@ -26,12 +26,12 @@ def format_yaml_like(data: dict, indent: int = 0) -> str:
             yaml_str += f"{spaces}{key}: {value}\\n"
     return yaml_str
 
-adatas = dict(zip("${names}".split(), [sc.read_h5ad(f) for f in "${h5ads}".split()]))
+adatas = dict(zip("${names}"[1:-1].split(", "), [sc.read_h5ad(f) for f in "${h5ads}".split()]))
 genes = [adata.var_names for adata in adatas.values()]
 
-adata_outer = ad.concat(adatas, join="outer", index_unique="-")
+adata_outer = ad.concat(adatas, join="outer", merge="first")
 adata_outer.X = csr_matrix(adata_outer.X)
-adata_outer.layers["counts"] = adata_outer.X
+adata_outer.layers["counts"] = adata_outer.X.copy()
 adata_outer.layers["log1p"] = sc.pp.log1p(adata_outer.X)
 
 # Make sure there are no cells and genes without any counts


### PR DESCRIPTION
- correct sample name splitting:
- do not update obs_names (they are already unique) 
- store a copy of X in layer (not a view)