### PR TITLE
Fix `meta.expected_cells` not passing to commnad call (#88)

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -58,7 +58,7 @@ process {
         ext.args = {
             [
                 "--epochs ${params.cellbender_epochs}",
-                meta.expected_cells > 0 ? '--expected-cells ${meta.expected_cells}' : ''
+                meta.expected_cells > 0 ? "--expected-cells ${meta.expected_cells}" : ''
             ].join(' ').trim()
         }
 


### PR DESCRIPTION
This should resolve meta.expected_cell not passing to the command line.

- [ ] If you've fixed a bug or added code that should be tested, add tests!

