### PR TITLE
Implement QC anndata finalization

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -218,6 +218,16 @@ process {
         ]
     }
 
+    withName: FINALIZE_QC_ANNDATAS {
+        ext.prefix = { meta.id + '_qc' }
+        publishDir = [
+            path: { "${params.outdir}/quality_control/finalized" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_intermediates,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+        ]
+    }
+
     withName: MYGENE {
         ext.prefix = { meta.id + '_mygene' }
         ext.input_col = { meta.geneid_col }

--- a/modules/local/adata/extend/templates/extend.py
+++ b/modules/local/adata/extend/templates/extend.py
@@ -40,12 +40,20 @@ def simple_name(path):
     basename = os.path.basename(path)
     return basename[:basename.rfind(".")]
 
+def load_pickle_or_csv(path):
+    if path.endswith(".pkl"):
+        return pd.read_pickle(path)
+    elif path.endswith(".csv"):
+        return pd.read_csv(path)
+    else:
+        raise ValueError(f"Unsupported file extension: {path}")
+
 for path in obs_paths:
-    df = pd.read_pickle(path).reindex(adata.obs_names)
+    df = load_pickle_or_csv(path).reindex(adata.obs_names)
     adata.obs = pd.concat([adata.obs, df], axis=1)
 
 for path in var_paths:
-    df = pd.read_pickle(path).reindex(adata.var_names)
+    df = load_pickle_or_csv(path).reindex(adata.var_names)
     adata.var = pd.concat([adata.var, df], axis=1)
 
 for path in obsm_paths:

--- a/modules/local/celltypes/celltypist/main.nf
+++ b/modules/local/celltypes/celltypist/main.nf
@@ -1,27 +1,27 @@
 process CELLTYPES_CELLTYPIST {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://community.wave.seqera.io/library/celltypist_scanpy:89a98f51262cfff4':
-        'community.wave.seqera.io/library/celltypist_scanpy:44b604b24dd4cf33' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'oras://community.wave.seqera.io/library/celltypist_scanpy:89a98f51262cfff4'
+        : 'community.wave.seqera.io/library/celltypist_scanpy:44b604b24dd4cf33'}"
 
     input:
     tuple val(meta), path(h5ad)
-    val(models)
+    val models
 
     output:
     tuple val(meta), path("*.h5ad"), emit: h5ad
-    path "*.pkl"                   , emit: obs
-    path "versions.yml"            , emit: versions
+    tuple val(meta), path("*.pkl"), emit: obs
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
-    template 'celltypist.py'
+    template('celltypist.py')
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"

--- a/workflows/scdownstream.nf
+++ b/workflows/scdownstream.nf
@@ -4,21 +4,22 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { LOAD_H5AD              } from '../subworkflows/local/load_h5ad'
-include { QUALITY_CONTROL        } from '../subworkflows/local/quality_control'
-include { UNIFY                  } from '../subworkflows/local/unify'
-include { CELLTYPE_ASSIGNMENT    } from '../subworkflows/local/celltype_assignment'
-include { COMBINE                } from '../subworkflows/local/combine'
-include { ADATA_SPLITEMBEDDINGS  } from '../modules/local/adata/splitembeddings'
-include { CLUSTER                } from '../subworkflows/local/cluster'
-include { PSEUDOBULKING          } from '../subworkflows/local/pseudobulking'
-include { PER_GROUP              } from '../subworkflows/local/per_group'
-include { FINALIZE               } from '../subworkflows/local/finalize'
-include { MULTIQC                } from '../modules/nf-core/multiqc/main'
-include { paramsSummaryMap       } from 'plugin/nf-schema'
-include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_scdownstream_pipeline'
+include { LOAD_H5AD                            } from '../subworkflows/local/load_h5ad'
+include { QUALITY_CONTROL                      } from '../subworkflows/local/quality_control'
+include { UNIFY                                } from '../subworkflows/local/unify'
+include { CELLTYPE_ASSIGNMENT                  } from '../subworkflows/local/celltype_assignment'
+include { ADATA_EXTEND as FINALIZE_QC_ANNDATAS } from '../modules/local/adata/extend'
+include { COMBINE                              } from '../subworkflows/local/combine'
+include { ADATA_SPLITEMBEDDINGS                } from '../modules/local/adata/splitembeddings'
+include { CLUSTER                              } from '../subworkflows/local/cluster'
+include { PSEUDOBULKING                        } from '../subworkflows/local/pseudobulking'
+include { PER_GROUP                            } from '../subworkflows/local/per_group'
+include { FINALIZE                             } from '../subworkflows/local/finalize'
+include { MULTIQC                              } from '../modules/nf-core/multiqc/main'
+include { paramsSummaryMap                     } from 'plugin/nf-schema'
+include { paramsSummaryMultiqc                 } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { softwareVersionsToYAML               } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { methodsDescriptionText               } from '../subworkflows/local/utils_nfcore_scdownstream_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,6 +45,13 @@ workflow SCDOWNSTREAM {
     ch_multiqc_files = Channel.empty()
 
     if (params.input) {
+        ch_obs_per_sample = Channel.empty()
+        ch_var_per_sample = Channel.empty()
+        ch_obsm_per_sample = Channel.empty()
+        ch_obsp_per_sample = Channel.empty()
+        ch_uns_per_sample = Channel.empty()
+        ch_layers_per_sample = Channel.empty()
+
         //
         // Load/Convert input to h5ad
         //
@@ -66,7 +74,20 @@ workflow SCDOWNSTREAM {
         //
         CELLTYPE_ASSIGNMENT(ch_h5ad)
         ch_versions = ch_versions.mix(CELLTYPE_ASSIGNMENT.out.versions)
-        ch_h5ad = CELLTYPE_ASSIGNMENT.out.h5ad
+        ch_obs_per_sample = ch_obs_per_sample.mix(CELLTYPE_ASSIGNMENT.out.obs)
+
+        FINALIZE_QC_ANNDATAS(ch_h5ad
+            .join(ch_obs_per_sample.groupTuple(), remainder: true)
+            .join(ch_var_per_sample.groupTuple(), remainder: true)
+            .join(ch_obsm_per_sample.groupTuple(), remainder: true)
+            .join(ch_obsp_per_sample.groupTuple(), remainder: true)
+            .join(ch_uns_per_sample.groupTuple(), remainder: true)
+            .join(ch_layers_per_sample.groupTuple(), remainder: true)
+            .map { meta, h5ad, obs, var, obsm, obsp, uns, layers ->
+                [meta, h5ad, obs ?: [], var ?: [], obsm ?: [], obsp ?: [], uns ?: [], layers ?: []] }
+        )
+        ch_h5ad = FINALIZE_QC_ANNDATAS.out.h5ad
+        ch_versions = ch_versions.mix(FINALIZE_QC_ANNDATAS.out.versions)
 
         if (!params.qc_only) {
             //


### PR DESCRIPTION
The new `FINALIZE_QC_ANNDATAS` in `workflows/scdownstream.nf` allows aggregating all the files in ch_obs (and other channels like ch_var etc) onto a base anndata object. This also supports CSV files (additionally to pickle files) now. Note that the CELLTYPIST process was updated: It now emits `obs` as a tuple, to also contain the `meta`. This is necessary, as otherwise we would not know which sample a certain pickle file belongs to.