### PR TITLE
add accelerator process directive

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -64,5 +64,6 @@ process {
     }
     withLabel: process_gpu {
         ext.use_gpu = { workflow.profile.contains('gpu') }
+        accelerator = 1
     }
 }

--- a/conf/base.config
+++ b/conf/base.config
@@ -64,6 +64,6 @@ process {
     }
     withLabel: process_gpu {
         ext.use_gpu = { workflow.profile.contains('gpu') }
-        accelerator = 1
+        accelerator = { workflow.profile.contains('gpu') ? 1 : null }
     }
 }


### PR DESCRIPTION
This is a fix for the issue https://github.com/nf-core/scdownstream/issues/192 to use GPU-enabled compute instances instances in cloud execution environments by setting the `accelerator` process directive when the `gpu` profile is active
