### PR TITLE
Remove r_repr calls and replace with rpy2 python methods

### DIFF
--- a/modules/local/adata/readrds/templates/readrds.py
+++ b/modules/local/adata/readrds/templates/readrds.py
@@ -36,11 +36,11 @@ def format_yaml_like(data: dict, indent: int = 0) -> str:
 rds_obj = ro.r(f'readRDS("${rds}")')
 
 # Check if it's already a SingleCellExperiment
-is_sce = ro.r(f'inherits(x = {rds_obj.r_repr()}, what = "SingleCellExperiment")')[0]
+is_sce = 'SingleCellExperiment' in rds_obj.extends()
 
 # Convert only if not already a SingleCellExperiment
 if not is_sce:
-    sce = ro.r(f'as.SingleCellExperiment({rds_obj.r_repr()})')
+    sce = seurat.as_SingleCellExperiment(rds_obj)
 else:
     sce = rds_obj
 


### PR DESCRIPTION
<!--
# nf-core/scdownstream pull request

Many thanks for contributing to nf-core/scdownstream!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scdownstream/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scdownstream/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scdownstream _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Addressing Issue #205 

Changed two lines in `modules/local/adata/readrds/templates/readrds.py` to remove the calls to `.r_repr()`, which can use up gigabytes of memory due to it returning an entire string representation of the single cell data objects.

Line 39:
Update to use the `.extends()` python method of `rds_obj`, which contains all the classes that `rds_obj` inherits from.

Line 43:
Call `seurat.as_SingleCellExperiment(rds_obj)` directly using the python interface rather than using an R command.