### PR TITLE
Celltypist symbol col assignmnet fix

### DIFF
--- a/modules/local/celltypes/celltypist/templates/celltypist.py
+++ b/modules/local/celltypes/celltypist/templates/celltypist.py
@@ -47,7 +47,7 @@ symbol_col = "${symbol_col}"
 if symbol_col != "index" and symbol_col:
     if symbol_col not in adata_celltypist.var.columns:
         raise ValueError(f"Symbol column {symbol_col} not found in adata.var.columns")
-    adata_celltypist.var_names = adata_celltypist.var[symbol_col]
+    adata_celltypist.var_names = adata_celltypist.var[symbol_col].to_list()
 
 df_list = []
 

--- a/modules/local/liana/rankaggregate/templates/rank_aggregate.py
+++ b/modules/local/liana/rankaggregate/templates/rank_aggregate.py
@@ -39,6 +39,11 @@ adata = sc.read_h5ad("${h5ad}")
 prefix = "${prefix}"
 obs_key = "${obs_key}"
 
+# Ensure that var_names are strings (not categorical) and unique
+# For some reason this happens when coming from scanvi, maybe also given the other changes
+adata.var_names = adata.var_names.astype(str)
+adata.var_names_make_unique()
+
 if adata.obs[obs_key].nunique() > 1:
     if (adata.X < 0).nnz == 0:
         sc.pp.log1p(adata)

--- a/modules/local/scvitools/scanvi/templates/scanvi.py
+++ b/modules/local/scvitools/scanvi/templates/scanvi.py
@@ -25,6 +25,40 @@ adata = ad.read_h5ad("${h5ad}")
 reference_model_path = "reference_model"
 reference_model_type = "${meta2.id}"
 
+# FIXME: This is a hack, the columns from celltypist are:
+# f"celltypist:{model_name}", f"celltypist:{model_name}:conf" (from line 69)
+# But here it expects the labels under "label" currently it seems that no
+# script triggered is handling confidence cutoff and label assignment to
+# "${label_col}" ("label").
+# Here I hack a solution in the event celltypist is used:
+# Overwrite labels with CellTypist predictions (with confidence filter)
+# Find any CellTypist prediction/confidence columns
+pred_cols = [
+    c
+    for c in adata.obs.columns
+    if c.startswith("celltypist:") and not c.endswith(":conf")
+]
+
+# If multiple models are present, I will pick the first one
+pred_col = pred_cols[0]
+conf_col = pred_col + ":conf"
+
+print(f"Using CellTypist column: {pred_col}")
+
+if conf_col in adata.obs:
+    CUTOFF = 0.7
+    adata.obs["${label_col}"] = adata.obs.apply(
+        lambda r: r[pred_col] if r[conf_col] >= CUTOFF else "unknown", axis=1
+    )
+else:
+    adata.obs["${label_col}"] = adata.obs[pred_col]
+
+# Make sure labels are categorical and contain "unknown"
+adata.obs["${label_col}"] = adata.obs["${label_col}"].astype("category")
+if "unknown" not in adata.obs["${label_col}"].cat.categories:
+    adata.obs["${label_col}"] = adata.obs["${label_col}"].cat.add_categories(["unknown"])
+# ---- End Hack ----
+
 if reference_model_type == "scanvi":
     SCANVI.prepare_query_anndata(adata, reference_model_path)
     model = SCANVI.load_query_data(adata, reference_model_path)


### PR DESCRIPTION
<!--
# nf-core/scdownstream pull request

Many thanks for contributing to nf-core/scdownstream!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scdownstream/tree/master/.github/CONTRIBUTING.md)
-->

## PR Notes
I fully do NOT intend for this PR to be merged as is. 

**Problem 1:** When using the .h5ed from scrnaseq pipeline, you must set symbol_col to a column that is `categorical`, but this is incompatible with anndata objects's var_names (when calling the function to make unique indexes). The first fix is to simply cast the pd.Series to a list when assigning it to adata.var_names.

**Problem 2:** This gets a little more dicey, When trying to boot strap scanvi from celltypist, it's hard to know/non-obvious the name of the celltypist column before hand that's needed for Celltypist labels, as it expect them to be in the 'label_col' column, which is empty. I still believe this can be changed elsewhere, or maybe I'm just wrong in my approach, Please correct me, im not an expert with scrnaseq.

**Problem 3:** Similar to 1, adata.var_names becomes categorical again, There should be a nicer place to change this upstream, but I cant find it right now.

**Additional:** I couldn't the debug profile to behave nicely, maybe something is wrong? 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scdownstream/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/scdownstream _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).

