### PR TITLE
Make mito percentage calculation more flexible

### DIFF
--- a/modules/local/scanpy/filter/main.nf
+++ b/modules/local/scanpy/filter/main.nf
@@ -1,24 +1,25 @@
 process SCANPY_FILTER {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://community.wave.seqera.io/library/pyyaml_scanpy:158b12038812cf13':
-        'community.wave.seqera.io/library/pyyaml_scanpy:61c9ab8e312bbe0a' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'oras://community.wave.seqera.io/library/pyyaml_scanpy:158b12038812cf13'
+        : 'community.wave.seqera.io/library/pyyaml_scanpy:61c9ab8e312bbe0a'}"
 
     input:
     tuple val(meta), path(h5ad)
-    val(symbol_col)
-    val(min_genes)
-    val(min_cells)
-    val(min_counts_gene)
-    val(min_counts_cell)
-    val(max_mito_percentage)
+    val symbol_col
+    val min_genes
+    val min_cells
+    val min_counts_gene
+    val min_counts_cell
+    val max_mito_percentage
+    path mito_genes
 
     output:
     tuple val(meta), path("${prefix}.h5ad"), emit: h5ad
-    path "versions.yml"            , emit: versions
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,9 +27,9 @@ process SCANPY_FILTER {
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
     if ("${prefix}.h5ad" == "${h5ad}") {
-        error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
     }
-    template 'filter.py'
+    template('filter.py')
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/local/scanpy/filter/main.nf
+++ b/modules/local/scanpy/filter/main.nf
@@ -9,6 +9,7 @@ process SCANPY_FILTER {
 
     input:
     tuple val(meta), path(h5ad)
+    val(symbol_col)
     val(min_genes)
     val(min_cells)
     val(min_counts_gene)

--- a/modules/local/scanpy/filter/templates/filter.py
+++ b/modules/local/scanpy/filter/templates/filter.py
@@ -15,8 +15,11 @@ sc.settings.n_jobs = int("${task.cpus}")
 
 adata = sc.read_h5ad("${h5ad}")
 prefix = "${prefix}"
+symbol_col = "${symbol_col}"
 
-adata.var["mt"] = adata.var_names.str.lower().str.startswith("mt-")
+symbols = adata.var_names if symbol_col == "index" else adata.var[symbol_col]
+
+adata.var["mt"] = symbols.str.lower().str.startswith("mt-")
 sc.pp.calculate_qc_metrics(
     adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
 )

--- a/modules/local/scanpy/filter/templates/filter.py
+++ b/modules/local/scanpy/filter/templates/filter.py
@@ -9,6 +9,7 @@ os.environ["NUMBA_CACHE_DIR"] = "./tmp/numba"
 import yaml
 import scanpy as sc
 from threadpoolctl import threadpool_limits
+
 threadpool_limits(int("${task.cpus}"))
 sc.settings.n_jobs = int("${task.cpus}")
 
@@ -16,10 +17,21 @@ sc.settings.n_jobs = int("${task.cpus}")
 adata = sc.read_h5ad("${h5ad}")
 prefix = "${prefix}"
 symbol_col = "${symbol_col}"
+mito_genes = "${mito_genes}"
 
 symbols = adata.var_names if symbol_col == "index" else adata.var[symbol_col]
 
-adata.var["mt"] = symbols.str.lower().str.startswith("mt-")
+if mito_genes:
+    with open(mito_genes, "r") as f:
+        mito_genes = {
+            line.strip().lower()
+            for line in f
+            if line.strip() and not line.startswith("#")
+        }
+    adata.var["mt"] = symbols.str.lower().isin(mito_genes)
+else:
+    adata.var["mt"] = symbols.str.lower().str.startswith("mt-")
+
 sc.pp.calculate_qc_metrics(
     adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
 )
@@ -36,10 +48,7 @@ adata.write_h5ad(f"{prefix}.h5ad")
 # Versions
 
 versions = {
-    "${task.process}": {
-        "python": platform.python_version(),
-        "scanpy": sc.__version__
-    }
+    "${task.process}": {"python": platform.python_version(), "scanpy": sc.__version__}
 }
 
 with open("versions.yml", "w") as f:

--- a/modules/local/scanpy/filter/tests/main.nf.test
+++ b/modules/local/scanpy/filter/tests/main.nf.test
@@ -40,6 +40,107 @@ nextflow_process {
 
     }
 
+
+    test("Should run without failures - with custom symbol column") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
+                    ]
+                )
+                input[1] = 'symbols'
+                input[2] = 20
+                input[3] = 20
+                input[4] = 50
+                input[5] = 50
+                input[6] = 50
+                input[7] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("Should run fail with a symbol column that does not exist") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
+                    ]
+                )
+                input[1] = 'not_a_column'
+                input[2] = 20
+                input[3] = 20
+                input[4] = 50
+                input[5] = 50
+                input[6] = 50
+                input[7] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.failed },
+            { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("Should run without failures - with custom mito genes") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
+                    ]
+                )
+                input[1] = 'index'
+                input[2] = 20
+                input[3] = 20
+                input[4] = 50
+                input[5] = 50
+                input[6] = 50
+                input[7] = Channel.of('POMP', 'DLG2')
+                    .collectFile(name: 'mito_genes.txt')
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
     test("Should run without failures - stub") {
 
         options '-stub'

--- a/modules/local/scanpy/filter/tests/main.nf.test
+++ b/modules/local/scanpy/filter/tests/main.nf.test
@@ -20,11 +20,13 @@ nextflow_process {
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
                     ]
                 )
-                input[1] = 20
+                input[1] = 'index'
                 input[2] = 20
-                input[3] = 50
+                input[3] = 20
                 input[4] = 50
                 input[5] = 50
+                input[6] = 50
+                input[7] = []
                 """
             }
         }
@@ -53,11 +55,13 @@ nextflow_process {
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
                     ]
                 )
-                input[1] = 20
+                input[1] = 'index'
                 input[2] = 20
-                input[3] = 50
+                input[3] = 20
                 input[4] = 50
                 input[5] = 50
+                input[6] = 50
+                input[7] = []
                 """
             }
         }

--- a/modules/local/scanpy/filter/tests/main.nf.test.snap
+++ b/modules/local/scanpy/filter/tests/main.nf.test.snap
@@ -1,4 +1,60 @@
 {
+    "Should run fail with a symbol column that does not exist": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "h5ad": [
+                    
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T19:19:53.484559762"
+    },
+    "Should run without failures - with custom symbol column": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_filtered.h5ad:md5,5e4f50b4961a1d67a1091056868f34a0"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,eb55aaa26e52e20f7fe07128dde4596f"
+                ],
+                "h5ad": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_filtered.h5ad:md5,5e4f50b4961a1d67a1091056868f34a0"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,eb55aaa26e52e20f7fe07128dde4596f"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T19:20:51.655325446"
+    },
     "Should run without failures - stub": {
         "content": [
             {
@@ -63,6 +119,39 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-13T20:45:46.706968088"
+        "timestamp": "2025-09-10T19:20:31.286725518"
+    },
+    "Should run without failures - with custom mito genes": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_filtered.h5ad:md5,5e4f50b4961a1d67a1091056868f34a0"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,eb55aaa26e52e20f7fe07128dde4596f"
+                ],
+                "h5ad": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_filtered.h5ad:md5,5e4f50b4961a1d67a1091056868f34a0"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,eb55aaa26e52e20f7fe07128dde4596f"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T19:24:01.401506209"
     }
 }

--- a/modules/local/seurat/integration/tests/main.nf.test
+++ b/modules/local/seurat/integration/tests/main.nf.test
@@ -26,11 +26,13 @@ nextflow_process {
             process {
                 """
                 input[0] = SCANPY_HVGS.out.h5ad
-                input[1] = 1
+                input[1] = "index"
                 input[2] = 1
                 input[3] = 1
                 input[4] = 1
-                input[5] = 100
+                input[5] = 1
+                input[6] = 100
+                input[7] = []
                 """
             }
         }

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,18 +9,19 @@
 // Global default params, used in configs
 params {
     // Input/output options
-    input                        = null
-    outdir                       = null
-    save_intermediates           = false
-    email                        = null
+    input                         = null
+    outdir                        = null
+    save_intermediates            = false
+    email                         = null
 
     // Unify options
-    unify_gene_symbols           = false
-    duplicate_var_resolution     = 'sum'
-    force_obs_cols               = ''
-    aggregate_isoforms           = false
+    unify_gene_symbols            = false
+    duplicate_var_resolution      = 'sum'
+    force_obs_cols                = ''
+    aggregate_isoforms            = false
 
     // Quality control options
+    mito_genes                    = null
     ambient_correction            = 'decontx'
     ambient_corrected_integration = false
     doublet_detection             = 'scrublet'
@@ -28,88 +29,88 @@ params {
     cellbender_epochs             = 150
 
     // Integration options
-    integration_methods          = 'scvi'
-    integration_hvgs             = 0
-    scvi_model                   = null
-    scanvi_model                 = null
-    scimilarity_model            = 'https://zenodo.org/records/10685499/files/model_v1.1.tar.gz'
+    integration_methods           = 'scvi'
+    integration_hvgs              = 0
+    scvi_model                    = null
+    scanvi_model                  = null
+    scimilarity_model             = 'https://zenodo.org/records/10685499/files/model_v1.1.tar.gz'
 
     // Extension options
-    base_adata                   = null
-    base_embeddings              = null
-    base_label_col               = 'label'
+    base_adata                    = null
+    base_embeddings               = null
+    base_label_col                = 'label'
 
     // Clustering options
-    clustering_resolutions       = '0.5,1.0'
-    cluster_per_label            = false
-    cluster_global               = true
+    clustering_resolutions        = '0.5,1.0'
+    cluster_per_label             = false
+    cluster_global                = true
 
     // Tool options
-    celltypist_model             = ''
-    celldex_reference            = ''
+    celltypist_model              = ''
+    celldex_reference             = ''
 
     // Pipeline options
-    qc_only                      = false
-    skip_liana                   = false
-    skip_rankgenesgroups         = false
-    pseudobulk                   = false
-    prep_cellxgene               = false
+    qc_only                       = false
+    skip_liana                    = false
+    skip_rankgenesgroups          = false
+    pseudobulk                    = false
+    prep_cellxgene                = false
 
     // scVI options
-    scvi_n_latent                = 30
-    scvi_n_hidden                = 128
-    scvi_n_layers                = 2
-    scvi_dispersion              = 'gene'
-    scvi_gene_likelihood         = 'zinb'
-    scvi_max_epochs              = null
-    scvi_categorical_covariates  = ''
-    scvi_continuous_covariates   = ''
+    scvi_n_latent                 = 30
+    scvi_n_hidden                 = 128
+    scvi_n_layers                 = 2
+    scvi_dispersion               = 'gene'
+    scvi_gene_likelihood          = 'zinb'
+    scvi_max_epochs               = null
+    scvi_categorical_covariates   = ''
+    scvi_continuous_covariates    = ''
 
     // Pseudobulking options
-    pseudobulk_groupby_labels    = 'batch'
-    pseudobulk_min_num_cells     = 5
+    pseudobulk_groupby_labels     = 'batch'
+    pseudobulk_min_num_cells      = 5
 
     // Resource options
-    memory_scale                 = 1
-    use_gpu                      = false
+    memory_scale                  = 1
+    use_gpu                       = false
 
     // MultiQC options
-    multiqc_config               = null
-    multiqc_title                = null
-    multiqc_logo                 = null
-    max_multiqc_email_size       = '25.MB'
-    multiqc_methods_description  = null
+    multiqc_config                = null
+    multiqc_title                 = null
+    multiqc_logo                  = null
+    max_multiqc_email_size        = '25.MB'
+    multiqc_methods_description   = null
 
     // Celltype assignemnt options
-    celltypist_model             = null
-    celldex_reference            = null
+    celltypist_model              = null
+    celldex_reference             = null
 
     // Boilerplate options
-    outdir                       = null
-    publish_dir_mode             = 'copy'
-    email                        = null
-    email_on_fail                = null
-    plaintext_email              = false
-    monochrome_logs              = false
-    hook_url                     = null
-    help                         = false
-    help_full                    = false
-    show_hidden                  = false
-    version                      = false
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/be82517a080e70628dce694c61eb91821850aea9/'
-    trace_report_suffix          = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
+    outdir                        = null
+    publish_dir_mode              = 'copy'
+    email                         = null
+    email_on_fail                 = null
+    plaintext_email               = false
+    monochrome_logs               = false
+    hook_url                      = null
+    help                          = false
+    help_full                     = false
+    show_hidden                   = false
+    version                       = false
+    pipelines_testdata_base_path  = 'https://raw.githubusercontent.com/nf-core/test-datasets/be82517a080e70628dce694c61eb91821850aea9/'
+    trace_report_suffix           = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
     // Config options
-    config_profile_name          = null
-    config_profile_description   = null
+    config_profile_name           = null
+    config_profile_description    = null
 
-    custom_config_version        = 'master'
-    custom_config_base           = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
-    config_profile_contact       = null
-    config_profile_url           = null
+    custom_config_version         = 'master'
+    custom_config_base            = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
+    config_profile_contact        = null
+    config_profile_url            = null
 
 
     // Schema validation default options
-    validate_params              = true
+    validate_params               = true
 }
 
 // Load base.config by default for all pipelines
@@ -331,7 +332,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.4.2' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.4.2'
 }
 
 validation {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -83,6 +83,12 @@
             "fa_icon": "fas fa-check-circle",
             "description": "Options for quality control of the input data.",
             "properties": {
+                "mito_genes": {
+                    "type": "string",
+                    "format": "file-path",
+                    "description": "Optional file containing a list of mitochondrial gene symbols (one per line). If provided, it overrides the default 'mt-' prefix heuristic.",
+                    "exists": true
+                },
                 "ambient_correction": {
                     "type": "string",
                     "default": "decontx",

--- a/subworkflows/local/integrate.nf
+++ b/subworkflows/local/integrate.nf
@@ -40,7 +40,7 @@ workflow INTEGRATE {
         // ch_var = ch_var.mix(SCANPY_HVGS.out.var)
 
         // Filter out empty cells from the AnnData object
-        SCANPY_FILTER(ch_h5ad_hvg, 1, 0, 0, 0, 100)
+        SCANPY_FILTER(ch_h5ad_hvg, "index", 1, 0, 0, 0, 100, [])
         ch_h5ad_hvg = SCANPY_FILTER.out.h5ad
         ch_versions = ch_versions.mix(SCANPY_FILTER.out.versions)
     }

--- a/subworkflows/local/quality_control/main.nf
+++ b/subworkflows/local/quality_control/main.nf
@@ -12,10 +12,11 @@ include { CUSTOM_COLLECTSIZES as COLLECT_SIZES                                  
 
 workflow QUALITY_CONTROL {
     take:
-    ch_h5ad // channel: [ meta, filtered, unfiltered ]
-    ambient_correction_method // value: string
-    doublet_detection_methods // value: list of strings
+    ch_h5ad                     // channel: [ meta, filtered, unfiltered ]
+    ambient_correction_method   // value: string
+    doublet_detection_methods   // value: list of strings
     doublet_detection_threshold // value: float
+    mito_genes                  // value: string (path) or null
 
     main:
     ch_versions = Channel.empty()
@@ -76,7 +77,7 @@ workflow QUALITY_CONTROL {
         min_counts_cell: meta.min_counts_cell ?: 0
         max_mito_percentage: meta.max_mito_percentage ?: 100
     }
-    SCANPY_FILTER(ch_filtering.h5ad, ch_filtering.symbol_col, ch_filtering.min_genes, ch_filtering.min_cells, ch_filtering.min_counts_gene, ch_filtering.min_counts_cell, ch_filtering.max_mito_percentage)
+    SCANPY_FILTER(ch_filtering.h5ad, ch_filtering.symbol_col, ch_filtering.min_genes, ch_filtering.min_cells, ch_filtering.min_counts_gene, ch_filtering.min_counts_cell, ch_filtering.max_mito_percentage, mito_genes ?: [])
     ch_h5ad = SCANPY_FILTER.out.h5ad
     ch_versions = ch_versions.mix(SCANPY_FILTER.out.versions)
 

--- a/subworkflows/local/quality_control/main.nf
+++ b/subworkflows/local/quality_control/main.nf
@@ -69,13 +69,14 @@ workflow QUALITY_CONTROL {
 
     ch_filtering = ch_h5ad.multiMap { meta, h5ad ->
         h5ad: [meta, h5ad]
+        symbol_col: meta.symbol_col ?: "index"
         min_genes: meta.min_genes ?: 0
         min_cells: meta.min_cells ?: 0
         min_counts_gene: meta.min_counts_gene ?: 0
         min_counts_cell: meta.min_counts_cell ?: 0
         max_mito_percentage: meta.max_mito_percentage ?: 100
     }
-    SCANPY_FILTER(ch_filtering.h5ad, ch_filtering.min_genes, ch_filtering.min_cells, ch_filtering.min_counts_gene, ch_filtering.min_counts_cell, ch_filtering.max_mito_percentage)
+    SCANPY_FILTER(ch_filtering.h5ad, ch_filtering.symbol_col, ch_filtering.min_genes, ch_filtering.min_cells, ch_filtering.min_counts_gene, ch_filtering.min_counts_cell, ch_filtering.max_mito_percentage)
     ch_h5ad = SCANPY_FILTER.out.h5ad
     ch_versions = ch_versions.mix(SCANPY_FILTER.out.versions)
 

--- a/subworkflows/local/quality_control/tests/main.nf.test
+++ b/subworkflows/local/quality_control/tests/main.nf.test
@@ -36,6 +36,36 @@ nextflow_workflow {
 
     }
 
+    test("Should run without ambient RNA removal and doublet detection, but with custom mito genes") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                        [ id: 'test', batch_col: 'sample', counts_layer: 'X' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
+                    ]
+                )
+                input[1] = 'none'
+                input[2] = []
+                input[3] = 0
+                input[4] = Channel.of('POMP', 'DLG2')
+                    .collectFile(name: 'mito_genes.txt')
+                """
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert snapshot(workflow.out).match()
+        }
+
+    }
+
     test("Should run with ambient RNA removal and doublet detection") {
 
         when {

--- a/subworkflows/local/quality_control/tests/main.nf.test
+++ b/subworkflows/local/quality_control/tests/main.nf.test
@@ -24,6 +24,7 @@ nextflow_workflow {
                 input[1] = 'none'
                 input[2] = []
                 input[3] = 0
+                input[4] = null
                 """
             }
         }
@@ -52,6 +53,7 @@ nextflow_workflow {
                 input[1] = 'decontx'
                 input[2] = ['scrublet']
                 input[3] = 1
+                input[4] = null
                 """
             }
         }
@@ -87,6 +89,7 @@ nextflow_workflow {
                 input[1] = 'decontx'
                 input[2] = ['scrublet']
                 input[3] = 1
+                input[4] = null
                 """
             }
         }

--- a/subworkflows/local/quality_control/tests/main.nf.test.snap
+++ b/subworkflows/local/quality_control/tests/main.nf.test.snap
@@ -58,6 +58,65 @@
         },
         "timestamp": "2025-08-10T19:18:27.976431873"
     },
+    "Should run without ambient RNA removal and doublet detection, but with custom mito genes": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "batch_col": "sample",
+                            "counts_layer": "X"
+                        },
+                        "test_filtered.h5ad:md5,bb91347fbd5e49a6ee1cacd09f143796"
+                    ]
+                ],
+                "1": [
+                    "sizes_mqc.json:md5,756ad6aae0f322aadfac95c2b38fcef2",
+                    "test_preprocessed_mqc.json:md5,7b489c3d05c36ea80996d97951cb4e68",
+                    "test_raw_mqc.json:md5,55fb1251be8f5e17f0ff337d94f7f3f8"
+                ],
+                "2": [
+                    "versions.yml:md5,42c1abd6c5e1c373ee37d53bcdcedd13",
+                    "versions.yml:md5,53938cd26fe63616cc4524da4b6062c5",
+                    "versions.yml:md5,6a3ffc8a47600e0ebd907bb979d5d859",
+                    "versions.yml:md5,88b8f8687e69ee5ccecf75b7e6845176",
+                    "versions.yml:md5,93254cb7ea8020ead8a711cde452236a",
+                    "versions.yml:md5,c4bcd7799f794fb7a2ab6b9a32d346f9",
+                    "versions.yml:md5,cd352ddaeb3e286706b51d74fe15d655"
+                ],
+                "h5ad": [
+                    [
+                        {
+                            "id": "test",
+                            "batch_col": "sample",
+                            "counts_layer": "X"
+                        },
+                        "test_filtered.h5ad:md5,bb91347fbd5e49a6ee1cacd09f143796"
+                    ]
+                ],
+                "multiqc_files": [
+                    "sizes_mqc.json:md5,756ad6aae0f322aadfac95c2b38fcef2",
+                    "test_preprocessed_mqc.json:md5,7b489c3d05c36ea80996d97951cb4e68",
+                    "test_raw_mqc.json:md5,55fb1251be8f5e17f0ff337d94f7f3f8"
+                ],
+                "versions": [
+                    "versions.yml:md5,42c1abd6c5e1c373ee37d53bcdcedd13",
+                    "versions.yml:md5,53938cd26fe63616cc4524da4b6062c5",
+                    "versions.yml:md5,6a3ffc8a47600e0ebd907bb979d5d859",
+                    "versions.yml:md5,88b8f8687e69ee5ccecf75b7e6845176",
+                    "versions.yml:md5,93254cb7ea8020ead8a711cde452236a",
+                    "versions.yml:md5,c4bcd7799f794fb7a2ab6b9a32d346f9",
+                    "versions.yml:md5,cd352ddaeb3e286706b51d74fe15d655"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-10T19:25:46.006504889"
+    },
     "Should run with ambient RNA removal and doublet detection - stub": {
         "content": [
             {

--- a/workflows/scdownstream.nf
+++ b/workflows/scdownstream.nf
@@ -67,6 +67,7 @@ workflow SCDOWNSTREAM {
             params.ambient_correction,
             !params.doublet_detection || params.doublet_detection == 'none' ? [] : params.doublet_detection.split(',').collect { it -> it.trim().toLowerCase() },
             params.doublet_detection_threshold,
+            params.mito_genes,
         )
         ch_versions = ch_versions.mix(QUALITY_CONTROL.out.versions)
         ch_multiqc_files = ch_multiqc_files.mix(QUALITY_CONTROL.out.multiqc_files)


### PR DESCRIPTION
- Bug fix: Mito percentage filtering now uses the `symbol_col` specified in the samplesheet to check for the `mt-` prefix
- Feature: New optional parameter `mito_genes`, as an alternative to checking for the `mt-` prefix. Expects a file with one gene per row.