### PR TITLE
Add option to exclude genes as candidate highly variable genes for integration

### DIFF
--- a/modules/local/scanpy/combat/tests/main.nf.test
+++ b/modules/local/scanpy/combat/tests/main.nf.test
@@ -18,6 +18,7 @@ nextflow_process {
                     ]
                 )
                 input[1] = 100
+                input[2] = []
                 """
             }
         }

--- a/modules/local/scanpy/hvgs/main.nf
+++ b/modules/local/scanpy/hvgs/main.nf
@@ -10,6 +10,7 @@ process SCANPY_HVGS {
     input:
     tuple val(meta), path(h5ad)
     val n_hvgs
+    path excluded_genes
 
     output:
     tuple val(meta), path("${prefix}.h5ad"), emit: h5ad

--- a/modules/local/scanpy/hvgs/templates/hvgs.py
+++ b/modules/local/scanpy/hvgs/templates/hvgs.py
@@ -18,6 +18,13 @@ prefix = "${prefix}"
 n_hvgs = int("${n_hvgs}")
 batch_key = "${batch_key}"
 
+# Remove excluded genes from the anndata prior to identifying highly variable genes
+if "${excluded_genes}":
+    with open("${excluded_genes}", "r") as f:
+        excluded_genes = [line.strip() for line in f if line.strip()]
+    mask = ~adata.var_names.isin(excluded_genes)
+    adata = adata[:, mask].copy()
+
 if adata.n_vars > n_hvgs and n_hvgs >= 0:
     kwargs = {}
 

--- a/modules/local/scanpy/hvgs/tests/main.nf.test
+++ b/modules/local/scanpy/hvgs/tests/main.nf.test
@@ -21,6 +21,7 @@ nextflow_process {
                     ]
                 )
                 input[1] = 0
+                input[2] = []
                 """
             }
         }
@@ -48,6 +49,36 @@ nextflow_process {
                     ]
                 )
                 input[1] = 100
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("Should run with a list of genes excluded from integration") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/combined_filtered_matrix.h5ad', checkIfExists: true)
+                    ]
+                )
+                input[1] = 100
+                input[2] = Channel.of('ANXA1\\nJCHAIN\\nGPNMB\\nHSPA12B\\nVCAN')
+                    .collectFile(name: 'excluded_genes.txt')
                 """
             }
         }
@@ -77,6 +108,7 @@ nextflow_process {
                     ]
                 )
                 input[1] = 100
+                input[2] = []
                 """
             }
         }

--- a/modules/local/scanpy/hvgs/tests/main.nf.test.snap
+++ b/modules/local/scanpy/hvgs/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,f1cfc42d33cf47fb46652e2f12d06da1"
+                        "test_hvg.h5ad:md5,9b4a85affd9e528002212b7ad303b326"
                     ]
                 ],
                 "1": [
@@ -21,7 +21,7 @@
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,f1cfc42d33cf47fb46652e2f12d06da1"
+                        "test_hvg.h5ad:md5,9b4a85affd9e528002212b7ad303b326"
                     ]
                 ],
                 "var": [
@@ -33,10 +33,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-12-29T22:42:05.041020271"
+        "timestamp": "2025-11-06T16:27:17.031827508"
     },
     "Should run without a specified number of HVGs": {
         "content": [
@@ -46,7 +46,7 @@
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,a8c70cd2c88e801de037f181e6830997"
+                        "test_hvg.h5ad:md5,d0f0107af7a6eee8d06606e7487e2695"
                     ]
                 ],
                 "1": [
@@ -60,7 +60,7 @@
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,a8c70cd2c88e801de037f181e6830997"
+                        "test_hvg.h5ad:md5,d0f0107af7a6eee8d06606e7487e2695"
                     ]
                 ],
                 "var": [
@@ -72,10 +72,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-12-29T22:41:41.979602625"
+        "timestamp": "2025-11-06T16:22:50.026974206"
     },
     "Should run without failures - stub": {
         "content": [
@@ -115,5 +115,44 @@
             "nextflow": "25.04.2"
         },
         "timestamp": "2025-06-03T07:49:56.630416945"
+    },
+    "Should run with a list of genes excluded from integration": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_hvg.h5ad:md5,a284845d9f9df76c64439b85677a5908"
+                    ]
+                ],
+                "1": [
+                    "test_hvg.pkl:md5,e7432bf749f3ff633369d0b3199a24c4"
+                ],
+                "2": [
+                    "versions.yml:md5,b2cac28d98d45ab02ed7d68691c897e7"
+                ],
+                "h5ad": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_hvg.h5ad:md5,a284845d9f9df76c64439b85677a5908"
+                    ]
+                ],
+                "var": [
+                    "test_hvg.pkl:md5,e7432bf749f3ff633369d0b3199a24c4"
+                ],
+                "versions": [
+                    "versions.yml:md5,b2cac28d98d45ab02ed7d68691c897e7"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-11-06T16:32:08.083057647"
     }
 }

--- a/modules/local/scanpy/hvgs/tests/main.nf.test.snap
+++ b/modules/local/scanpy/hvgs/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,9b4a85affd9e528002212b7ad303b326"
+                        "test_hvg.h5ad:md5,f1cfc42d33cf47fb46652e2f12d06da1"
                     ]
                 ],
                 "1": [
@@ -21,7 +21,7 @@
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,9b4a85affd9e528002212b7ad303b326"
+                        "test_hvg.h5ad:md5,f1cfc42d33cf47fb46652e2f12d06da1"
                     ]
                 ],
                 "var": [
@@ -33,10 +33,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-11-06T16:27:17.031827508"
+        "timestamp": "2026-01-10T14:31:10.528628881"
     },
     "Should run without a specified number of HVGs": {
         "content": [
@@ -46,7 +46,7 @@
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,d0f0107af7a6eee8d06606e7487e2695"
+                        "test_hvg.h5ad:md5,a8c70cd2c88e801de037f181e6830997"
                     ]
                 ],
                 "1": [
@@ -60,7 +60,7 @@
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,d0f0107af7a6eee8d06606e7487e2695"
+                        "test_hvg.h5ad:md5,a8c70cd2c88e801de037f181e6830997"
                     ]
                 ],
                 "var": [
@@ -72,10 +72,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-11-06T16:22:50.026974206"
+        "timestamp": "2026-01-10T14:30:48.127003632"
     },
     "Should run without failures - stub": {
         "content": [
@@ -124,35 +124,35 @@
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,a284845d9f9df76c64439b85677a5908"
+                        "test_hvg.h5ad:md5,4d3f42a1201d720b01d15133df67727d"
                     ]
                 ],
                 "1": [
                     "test_hvg.pkl:md5,e7432bf749f3ff633369d0b3199a24c4"
                 ],
                 "2": [
-                    "versions.yml:md5,b2cac28d98d45ab02ed7d68691c897e7"
+                    "versions.yml:md5,0dd6121b661ca9111145ac517cbdbac6"
                 ],
                 "h5ad": [
                     [
                         {
                             "id": "test"
                         },
-                        "test_hvg.h5ad:md5,a284845d9f9df76c64439b85677a5908"
+                        "test_hvg.h5ad:md5,4d3f42a1201d720b01d15133df67727d"
                     ]
                 ],
                 "var": [
                     "test_hvg.pkl:md5,e7432bf749f3ff633369d0b3199a24c4"
                 ],
                 "versions": [
-                    "versions.yml:md5,b2cac28d98d45ab02ed7d68691c897e7"
+                    "versions.yml:md5,0dd6121b661ca9111145ac517cbdbac6"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-11-06T16:32:08.083057647"
+        "timestamp": "2026-01-10T14:31:32.688923253"
     }
 }

--- a/modules/local/scvitools/scanvi/tests/main.nf.test
+++ b/modules/local/scvitools/scanvi/tests/main.nf.test
@@ -47,6 +47,7 @@ nextflow_process {
                 """
                 input[0] = SCANPY_LEIDEN.out.h5ad
                 input[1] = 100
+                input[2] = []
                 """
             }
         }

--- a/modules/local/seurat/integration/tests/main.nf.test
+++ b/modules/local/seurat/integration/tests/main.nf.test
@@ -18,6 +18,7 @@ nextflow_process {
                     ]
                 )
                 input[1] = 100
+                input[2] = []
                 """
             }
         }

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,7 @@ params {
     // Integration options
     integration_methods           = 'scvi'
     integration_hvgs              = 0
+    integration_excluded_genes    = null
     scvi_model                    = null
     scanvi_model                  = null
     scimilarity_model             = 'https://zenodo.org/records/10685499/files/model_v1.1.tar.gz'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -97,7 +97,6 @@
                 },
                 "ambient_corrected_integration": {
                     "type": "boolean",
-                    "default": false,
                     "description": "Whether to use the ambient-corrected counts for integration. Can be overridden by the `ambient_corrected_integration` in the sample sheet.",
                     "help_text": "ambient_corrected_integration must be a boolean."
                 },
@@ -138,6 +137,12 @@
                     "default": 0,
                     "description": "Number of highly variable genes to use for integration. If set to 0, the number of highly variable genes will be automatically determined. If set to a negative number, all genes will be used.",
                     "help_text": "If a reference model is provided, this does not have any effect. This is because the reference model defines the set of genes that will be used for integration."
+                },
+                "integration_excluded_genes": {
+                    "type": "string",
+                    "format": "file-path",
+                    "description": "Optional file containing a list of gene symbols (one per line). If provided, these genes will be excluded as candidate highly variable genes for integration.",
+                    "exists": true
                 },
                 "scvi_model": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -97,6 +97,7 @@
                 },
                 "ambient_corrected_integration": {
                     "type": "boolean",
+                    "default": false,
                     "description": "Whether to use the ambient-corrected counts for integration. Can be overridden by the `ambient_corrected_integration` in the sample sheet.",
                     "help_text": "ambient_corrected_integration must be a boolean."
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -142,7 +142,7 @@
                 "integration_excluded_genes": {
                     "type": "string",
                     "format": "file-path",
-                    "description": "Optional file containing a list of gene symbols (one per line). If provided, these genes will be excluded as candidate highly variable genes for integration.",
+                    "description": "Optional file containing a list of gene symbols (one per line). If provided, these genes will be excluded from highly variable genes selection for integration.",
                     "exists": true
                 },
                 "scvi_model": {

--- a/subworkflows/local/combine.nf
+++ b/subworkflows/local/combine.nf
@@ -28,6 +28,7 @@ workflow COMBINE {
         ADATA_MERGE.out.integrate,
         params.base_adata != null,
         params.integration_hvgs,
+        params.integration_excluded_genes ? file(params.integration_excluded_genes) : [],
         params.integration_methods.split(',').collect { it -> it.trim().toLowerCase() },
         params.scvi_model,
         params.scanvi_model,

--- a/subworkflows/local/integrate.nf
+++ b/subworkflows/local/integrate.nf
@@ -15,6 +15,7 @@ workflow INTEGRATE {
     ch_h5ad                     // channel: [ merged, h5ad ]
     is_extension                // boolean
     n_hvgs                      // integer
+    excluded_genes              // path
     methods                     // list of string
     scvi_model                  // path
     scanvi_model                // path
@@ -32,7 +33,7 @@ workflow INTEGRATE {
     // If a reference model is provided, only the genes in the reference model are used
     // Otherwise, we would intersect the HVGs, which is not what we want
     if (!is_extension && n_hvgs >= 0) {
-        SCANPY_HVGS(ch_h5ad, n_hvgs)
+        SCANPY_HVGS(ch_h5ad, n_hvgs, excluded_genes)
         ch_versions = ch_versions.mix(SCANPY_HVGS.out.versions)
         ch_h5ad_hvg = SCANPY_HVGS.out.h5ad
 


### PR DESCRIPTION
It is often preferable to exclude certain genes as candidate genes for integration. Some genes (e.g., heat shock proteins) may be highly variable but are not informative for assigning cell type.

This PR adds an option (--integration_excluded_genes) to input a list of genes (one per line) that will not be considered as candidate highly variable genes.

## PR checklist

- [✓] This comment contains a description of changes (with reason).
- [✓] If you've fixed a bug or added code that should be tested, add tests!
- [N/A] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scdownstream/tree/master/.github/CONTRIBUTING.md)
- [N/A] If necessary, also make a PR on the nf-core/scdownstream _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [✓] Make sure your code lints (`nf-core pipelines lint`).
- [✓] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [✓] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [N/A] Usage Documentation in `docs/usage.md` is updated.
- [N/A] Output Documentation in `docs/output.md` is updated.
- [N/A] `CHANGELOG.md` is updated.
- [N/A] `README.md` is updated (including new tool citations and authors/contributors).
