### PR TITLE
Cast var_names to string so make_unique_names works

### DIFF
--- a/modules/local/celltypes/celltypist/templates/celltypist.py
+++ b/modules/local/celltypes/celltypist/templates/celltypist.py
@@ -49,6 +49,10 @@ if symbol_col != "index" and symbol_col:
         raise ValueError(f"Symbol column {symbol_col} not found in adata.var.columns")
     adata_celltypist.var_names = adata_celltypist.var[symbol_col]
 
+# celltypist expects a string index, because it will make unique names by appending "-1", "-2"
+# to duplicates if necessary. Cast other types (e.g. CategoricalIndex) to str:
+adata_celltypist.var_names = adata_celltypist.var_names.astype(str)
+
 df_list = []
 
 for model in models:


### PR DESCRIPTION
Duplicities in var_names are handled by celltypist via anndata by appending "-1", "-2" to the gene name.

This requires the index to be of type str, hence the casting.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scdownstream/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scdownstream _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
