### PR TITLE
Abandon snapshot-based tests for hugo-unifier

### DIFF
--- a/modules/local/hugounifier/apply/tests/main.nf.test
+++ b/modules/local/hugounifier/apply/tests/main.nf.test
@@ -47,7 +47,12 @@ nextflow_process {
         then {
             assertAll(
             { assert process.success },
-            { assert snapshot(process.out).match() }
+            {
+                with(anndata(process.out.h5ad[0][1])) {
+                    assert var.rownames.size() > 0
+                    assert obs.rownames.size() > 0
+                }
+            }
             )
         }
 

--- a/modules/local/hugounifier/apply/tests/main.nf.test.snap
+++ b/modules/local/hugounifier/apply/tests/main.nf.test.snap
@@ -31,38 +31,5 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         }
-    },
-    "Should run without failures": {
-        "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_hugounifier.h5ad:md5,c7cdbd7262128dcbd7b90f845188e34f"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,ecf9df8f7cb2a1ab5594ad9543ee32d7"
-                ],
-                "h5ad": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_hugounifier.h5ad:md5,c7cdbd7262128dcbd7b90f845188e34f"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,ecf9df8f7cb2a1ab5594ad9543ee32d7"
-                ]
-            }
-        ],
-        "timestamp": "2026-03-10T07:58:54.198227455",
-        "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
-        }
     }
 }

--- a/modules/local/hugounifier/get/tests/main.nf.test
+++ b/modules/local/hugounifier/get/tests/main.nf.test
@@ -31,7 +31,17 @@ nextflow_process {
         then {
             assertAll(
             { assert process.success },
-            { assert snapshot(process.out).match() }
+            { assert process.out.changes[0][1].size() == 2 },
+            {
+                with(path(process.out.changes[0][1][0]).csv) {
+                    assert columnNames == ["action", "symbol", "new", "reason"]
+                }
+            },
+            {
+                with(path(process.out.changes[0][1][1]).csv) {
+                    assert columnNames == ["action", "symbol", "new", "reason"]
+                }
+            }
             )
         }
 

--- a/modules/local/hugounifier/get/tests/main.nf.test.snap
+++ b/modules/local/hugounifier/get/tests/main.nf.test.snap
@@ -37,44 +37,5 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         }
-    },
-    "Should run without failures": {
-        "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "sample1.csv:md5,912f7444a187b1f8094c1f85b5282945",
-                            "sample2.csv:md5,bba30f28971437148138af65bd42aee0"
-                        ]
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,4c8215f5c744a2bf227901bd8c53bf13"
-                ],
-                "changes": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "sample1.csv:md5,912f7444a187b1f8094c1f85b5282945",
-                            "sample2.csv:md5,bba30f28971437148138af65bd42aee0"
-                        ]
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,4c8215f5c744a2bf227901bd8c53bf13"
-                ]
-            }
-        ],
-        "timestamp": "2026-03-10T07:56:17.593716871",
-        "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
-        }
     }
 }

--- a/nf-test.config
+++ b/nf-test.config
@@ -21,5 +21,6 @@ config {
     plugins {
         load "nft-utils@0.0.3"
         load "nft-anndata@0.1.0"
+        load "nft-csv@0.1.0"
     }
 }

--- a/subworkflows/local/unify/tests/main.nf.test
+++ b/subworkflows/local/unify/tests/main.nf.test
@@ -119,6 +119,33 @@ nextflow_workflow {
 
     }
 
+    test("Should run without failures - symbol_col index, unify_gene_symbols false, snapshot stability") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+                unify_gene_symbols = false
+            }
+            workflow {
+                """
+                input[0] = channel.of([
+                    [id: 'test', symbol_col: 'index', batch_col: 'batch', label_col: ''],
+                    file(params.pipelines_testdata_base_path + '/anndata-variations/symbols_as_index.h5ad', checkIfExists: true)
+                ])
+                input[1] = false
+                input[2] = 'sum'
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert snapshot(workflow.out).match()
+        }
+
+    }
+
     test("Should run without failures - symbol_col index, unify_gene_symbols true - stub") {
 
         options '-stub'
@@ -169,8 +196,16 @@ nextflow_workflow {
         }
 
         then {
-            assert workflow.success
-            assert snapshot(workflow.out).match()
+            def filename = workflow.out.h5ad[0][1]
+            assertAll(
+            { assert workflow.success },
+            {
+                with(anndata(filename)) {
+                    assert var.rownames.size() > 0
+                    assert obs.rownames.size() > 0
+                }
+            }
+            )
         }
 
     }

--- a/subworkflows/local/unify/tests/main.nf.test.snap
+++ b/subworkflows/local/unify/tests/main.nf.test.snap
@@ -101,13 +101,13 @@
                 ]
             }
         ],
-        "timestamp": "2026-01-18T21:22:29.899026309",
+        "timestamp": "2026-01-18T21:22:29.899006309",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.2"
         }
     },
-    "Should run without failures - symbol_col index, unify_gene_symbols true": {
+    "Should run without failures - symbol_col index, unify_gene_symbols false, snapshot stability": {
         "content": [
             {
                 "0": [
@@ -121,7 +121,7 @@
                             "unknown_label": "unknown",
                             "counts_layer": "X"
                         },
-                        "test_unified.h5ad:md5,a9ac476adb2844de8640bf5fcaa0e0b9"
+                        "test_unified.h5ad:md5,634cda43f3cc2ce7ffeddcd8cb0a1e76"
                     ]
                 ],
                 "1": [
@@ -129,10 +129,7 @@
                 ],
                 "2": [
                     "versions.yml:md5,28f13636db3e448a09677ac7d2de39dc",
-                    "versions.yml:md5,4e6f35e1d0c91cec3120567db9f0bdfe",
-                    "versions.yml:md5,56867b1608bf70187c185b4fecb3eab7",
-                    "versions.yml:md5,b080fe0c3ed4678d71941f74947dc2e4",
-                    "versions.yml:md5,e9c711a68f147215c1754f64ca792664"
+                    "versions.yml:md5,b080fe0c3ed4678d71941f74947dc2e4"
                 ],
                 "h5ad": [
                     [
@@ -145,7 +142,7 @@
                             "unknown_label": "unknown",
                             "counts_layer": "X"
                         },
-                        "test_unified.h5ad:md5,a9ac476adb2844de8640bf5fcaa0e0b9"
+                        "test_unified.h5ad:md5,634cda43f3cc2ce7ffeddcd8cb0a1e76"
                     ]
                 ],
                 "multiqc_files": [
@@ -153,17 +150,14 @@
                 ],
                 "versions": [
                     "versions.yml:md5,28f13636db3e448a09677ac7d2de39dc",
-                    "versions.yml:md5,4e6f35e1d0c91cec3120567db9f0bdfe",
-                    "versions.yml:md5,56867b1608bf70187c185b4fecb3eab7",
-                    "versions.yml:md5,b080fe0c3ed4678d71941f74947dc2e4",
-                    "versions.yml:md5,e9c711a68f147215c1754f64ca792664"
+                    "versions.yml:md5,b080fe0c3ed4678d71941f74947dc2e4"
                 ]
             }
         ],
-        "timestamp": "2026-03-10T09:06:13.565614981",
+        "timestamp": "2026-03-12T19:00:45.019297969",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         }
     },
     "Should run without failures - symbol_col index, unify_gene_symbols false - stub": {
@@ -274,7 +268,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-01-18T17:41:17.198406767",
+        "timestamp": "2026-01-18T17:41:17.198064779",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"

--- a/subworkflows/local/unify_genes/tests/main.nf.test
+++ b/subworkflows/local/unify_genes/tests/main.nf.test
@@ -49,8 +49,16 @@ nextflow_workflow {
         }
 
         then {
-            assert workflow.success
-            assert snapshot(workflow.out).match()
+            def filename = workflow.out.h5ad[0][1]
+            assertAll(
+            { assert workflow.success },
+            {
+                with(anndata(filename)) {
+                    assert var.rownames.size() > 0
+                    assert obs.rownames.size() > 0
+                }
+            }
+            )
         }
 
     }
@@ -97,8 +105,21 @@ nextflow_workflow {
         }
 
         then {
-            assert workflow.success
-            assert snapshot(workflow.out).match()
+            assertAll(
+            { assert workflow.success },
+            {
+                with(anndata(workflow.out.h5ad[0][1])) {
+                    assert var.rownames.size() > 0
+                    assert obs.rownames.size() > 0
+                }
+            },
+            {
+                with(anndata(workflow.out.h5ad[1][1])) {
+                    assert var.rownames.size() > 0
+                    assert obs.rownames.size() > 0
+                }
+            }
+            )
         }
 
     }

--- a/subworkflows/local/unify_genes/tests/main.nf.test.snap
+++ b/subworkflows/local/unify_genes/tests/main.nf.test.snap
@@ -1,39 +1,4 @@
 {
-    "Should run without failures - single sample": {
-        "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_hugounifier.h5ad:md5,c7cdbd7262128dcbd7b90f845188e34f"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,a25a9f067f9ece70fa40d51efbcdbdee",
-                    "versions.yml:md5,ff9e30a2b6a2a38e584c66fc01f53b5e"
-                ],
-                "h5ad": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_hugounifier.h5ad:md5,c7cdbd7262128dcbd7b90f845188e34f"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,a25a9f067f9ece70fa40d51efbcdbdee",
-                    "versions.yml:md5,ff9e30a2b6a2a38e584c66fc01f53b5e"
-                ]
-            }
-        ],
-        "timestamp": "2026-03-10T08:00:45.100584607",
-        "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
-        }
-    },
     "Should run without failures - multiple samples - stub": {
         "content": [
             {
@@ -116,55 +81,6 @@
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
-        }
-    },
-    "Should run without failures - multiple samples": {
-        "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1_hugounifier.h5ad:md5,c7cdbd7262128dcbd7b90f845188e34f"
-                    ],
-                    [
-                        {
-                            "id": "test2"
-                        },
-                        "test2_hugounifier.h5ad:md5,c7cdbd7262128dcbd7b90f845188e34f"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,a25a9f067f9ece70fa40d51efbcdbdee",
-                    "versions.yml:md5,ff9e30a2b6a2a38e584c66fc01f53b5e",
-                    "versions.yml:md5,ff9e30a2b6a2a38e584c66fc01f53b5e"
-                ],
-                "h5ad": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1_hugounifier.h5ad:md5,c7cdbd7262128dcbd7b90f845188e34f"
-                    ],
-                    [
-                        {
-                            "id": "test2"
-                        },
-                        "test2_hugounifier.h5ad:md5,c7cdbd7262128dcbd7b90f845188e34f"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,a25a9f067f9ece70fa40d51efbcdbdee",
-                    "versions.yml:md5,ff9e30a2b6a2a38e584c66fc01f53b5e",
-                    "versions.yml:md5,ff9e30a2b6a2a38e584c66fc01f53b5e"
-                ]
-            }
-        ],
-        "timestamp": "2026-03-10T08:01:28.835317824",
-        "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
         }
     }
 }


### PR DESCRIPTION
This is necessary because recently the HUGO API changed their exact return values frequently multiple times, leading to hash changes in the processed anndata files