### PR TITLE
Fix CELLBENDER_MERGE for 10x Flex gene-set mismatch

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -18,7 +18,8 @@
                     "cellbender/merge": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/cellbender/merge/cellbender-merge.diff"
                     },
                     "cellbender/removebackground": {
                         "branch": "master",

--- a/modules/nf-core/cellbender/merge/cellbender-merge.diff
+++ b/modules/nf-core/cellbender/merge/cellbender-merge.diff
@@ -1,0 +1,20 @@
+Changes in component 'nf-core/cellbender/merge'
+'modules/nf-core/cellbender/merge/environment.yml' is unchanged
+'modules/nf-core/cellbender/merge/meta.yml' is unchanged
+'modules/nf-core/cellbender/merge/main.nf' is unchanged
+'modules/nf-core/cellbender/merge/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/cellbender/merge/tests/main.nf.test' is unchanged
+Changes in 'cellbender/merge/templates/merge.py':
+--- modules/nf-core/cellbender/merge/templates/merge.py
++++ modules/nf-core/cellbender/merge/templates/merge.py
+@@ -29,7 +29,7 @@
+ 
+ adata_cellbender = load_anndata_from_input_and_output("${unfiltered}", "${cellbender_h5}", analyzed_barcodes_only=False)
+ 
+-adata_cellbender = adata_cellbender[adata.obs_names]
++adata_cellbender = adata_cellbender[adata.obs_names, adata.var_names]
+ 
+ if "${output_layer}" == "X":
+     adata.X = adata_cellbender.layers["cellbender"]
+
+************************************************************

--- a/modules/nf-core/cellbender/merge/cellbender-merge.diff
+++ b/modules/nf-core/cellbender/merge/cellbender-merge.diff
@@ -7,66 +7,18 @@ Changes in component 'nf-core/cellbender/merge'
 Changes in 'cellbender/merge/templates/merge.py':
 --- modules/nf-core/cellbender/merge/templates/merge.py
 +++ modules/nf-core/cellbender/merge/templates/merge.py
-@@ -4,6 +4,8 @@
- 
- import anndata as ad
- import cellbender
-+import numpy as np
-+import pandas as pd
- from cellbender.remove_background.downstream import load_anndata_from_input_and_output
- 
- 
-@@ -25,11 +27,52 @@
-     return yaml_str
- 
- 
-+def var_alignment_keys(adata):
-+    if "probe_ids" in adata.var.columns:
-+        keys = adata.var["probe_ids"].astype(str)
-+        if keys.is_unique:
-+            return keys
-+    if "gene_ids" in adata.var.columns:
-+        keys = adata.var["gene_ids"].astype(str)
-+        if keys.is_unique:
-+            return keys
-+    keys = adata.var.index.astype(str)
-+    if keys.is_unique:
-+        return keys
-+    raise ValueError(
-+        "Cannot align CellBender output to the filtered matrix: no unique feature "
-+        "identifiers found among var `probe_ids`, `gene_ids`, or the var index."
-+    )
-+
-+
-+def subset_cellbender_to_filtered(adata, adata_cellbender):
-+    adata_cellbender = adata_cellbender[adata.obs_names]
-+    if adata.n_vars == adata_cellbender.n_vars:
-+        return adata_cellbender
-+
-+    target_keys = var_alignment_keys(adata)
-+    source_keys = var_alignment_keys(adata_cellbender)
-+
-+    source_positions = pd.Series(np.arange(adata_cellbender.n_vars), index=source_keys)
-+    if not source_positions.index.is_unique:
-+        source_positions = source_positions[~source_positions.index.duplicated(keep="first")]
-+
-+    positions = source_positions.loc[target_keys.values]
-+    if positions.isna().any():
-+        missing = target_keys[positions.isna()].unique()[:5]
-+        raise ValueError(
-+            "Features from the filtered matrix were not found in the CellBender output. "
-+            f"Examples: {list(missing)}"
-+        )
-+
-+    return adata_cellbender[:, positions.to_numpy(dtype=int)]
-+
-+
- adata = ad.read_h5ad("${filtered}")
+@@ -29,7 +29,13 @@
  
  adata_cellbender = load_anndata_from_input_and_output("${unfiltered}", "${cellbender_h5}", analyzed_barcodes_only=False)
  
 -adata_cellbender = adata_cellbender[adata.obs_names]
-+adata_cellbender = subset_cellbender_to_filtered(adata, adata_cellbender)
++# Subset to the barcodes and genes present in the filtered matrix.
++# Gene symbols (var index) may not be unique, so align on Ensembl IDs.
++# The filtered h5ad uses 'gene_ids'; load_anndata_from_input_and_output uses 'gene_id'.
++gene_id_col = "gene_id" if "gene_id" in adata_cellbender.var.columns else adata_cellbender.var.index.name
++cb_id_to_pos = {gid: i for i, gid in enumerate(adata_cellbender.var[gene_id_col])}
++var_positions = [cb_id_to_pos[gid] for gid in adata.var["gene_ids"]]
++adata_cellbender = adata_cellbender[adata.obs_names, var_positions]
  
  if "${output_layer}" == "X":
      adata.X = adata_cellbender.layers["cellbender"]

--- a/modules/nf-core/cellbender/merge/cellbender-merge.diff
+++ b/modules/nf-core/cellbender/merge/cellbender-merge.diff
@@ -7,12 +7,66 @@ Changes in component 'nf-core/cellbender/merge'
 Changes in 'cellbender/merge/templates/merge.py':
 --- modules/nf-core/cellbender/merge/templates/merge.py
 +++ modules/nf-core/cellbender/merge/templates/merge.py
-@@ -29,7 +29,7 @@
+@@ -4,6 +4,8 @@
+ 
+ import anndata as ad
+ import cellbender
++import numpy as np
++import pandas as pd
+ from cellbender.remove_background.downstream import load_anndata_from_input_and_output
+ 
+ 
+@@ -25,11 +27,52 @@
+     return yaml_str
+ 
+ 
++def var_alignment_keys(adata):
++    if "probe_ids" in adata.var.columns:
++        keys = adata.var["probe_ids"].astype(str)
++        if keys.is_unique:
++            return keys
++    if "gene_ids" in adata.var.columns:
++        keys = adata.var["gene_ids"].astype(str)
++        if keys.is_unique:
++            return keys
++    keys = adata.var.index.astype(str)
++    if keys.is_unique:
++        return keys
++    raise ValueError(
++        "Cannot align CellBender output to the filtered matrix: no unique feature "
++        "identifiers found among var `probe_ids`, `gene_ids`, or the var index."
++    )
++
++
++def subset_cellbender_to_filtered(adata, adata_cellbender):
++    adata_cellbender = adata_cellbender[adata.obs_names]
++    if adata.n_vars == adata_cellbender.n_vars:
++        return adata_cellbender
++
++    target_keys = var_alignment_keys(adata)
++    source_keys = var_alignment_keys(adata_cellbender)
++
++    source_positions = pd.Series(np.arange(adata_cellbender.n_vars), index=source_keys)
++    if not source_positions.index.is_unique:
++        source_positions = source_positions[~source_positions.index.duplicated(keep="first")]
++
++    positions = source_positions.loc[target_keys.values]
++    if positions.isna().any():
++        missing = target_keys[positions.isna()].unique()[:5]
++        raise ValueError(
++            "Features from the filtered matrix were not found in the CellBender output. "
++            f"Examples: {list(missing)}"
++        )
++
++    return adata_cellbender[:, positions.to_numpy(dtype=int)]
++
++
+ adata = ad.read_h5ad("${filtered}")
  
  adata_cellbender = load_anndata_from_input_and_output("${unfiltered}", "${cellbender_h5}", analyzed_barcodes_only=False)
  
 -adata_cellbender = adata_cellbender[adata.obs_names]
-+adata_cellbender = adata_cellbender[adata.obs_names, adata.var_names]
++adata_cellbender = subset_cellbender_to_filtered(adata, adata_cellbender)
  
  if "${output_layer}" == "X":
      adata.X = adata_cellbender.layers["cellbender"]

--- a/modules/nf-core/cellbender/merge/templates/merge.py
+++ b/modules/nf-core/cellbender/merge/templates/merge.py
@@ -29,7 +29,7 @@ adata = ad.read_h5ad("${filtered}")
 
 adata_cellbender = load_anndata_from_input_and_output("${unfiltered}", "${cellbender_h5}", analyzed_barcodes_only=False)
 
-adata_cellbender = adata_cellbender[adata.obs_names]
+adata_cellbender = adata_cellbender[adata.obs_names, adata.var_names]
 
 if "${output_layer}" == "X":
     adata.X = adata_cellbender.layers["cellbender"]

--- a/modules/nf-core/cellbender/merge/templates/merge.py
+++ b/modules/nf-core/cellbender/merge/templates/merge.py
@@ -4,8 +4,6 @@ import platform
 
 import anndata as ad
 import cellbender
-import numpy as np
-import pandas as pd
 from cellbender.remove_background.downstream import load_anndata_from_input_and_output
 
 
@@ -27,52 +25,17 @@ def format_yaml_like(data: dict, indent: int = 0) -> str:
     return yaml_str
 
 
-def var_alignment_keys(adata):
-    if "probe_ids" in adata.var.columns:
-        keys = adata.var["probe_ids"].astype(str)
-        if keys.is_unique:
-            return keys
-    if "gene_ids" in adata.var.columns:
-        keys = adata.var["gene_ids"].astype(str)
-        if keys.is_unique:
-            return keys
-    keys = adata.var.index.astype(str)
-    if keys.is_unique:
-        return keys
-    raise ValueError(
-        "Cannot align CellBender output to the filtered matrix: no unique feature "
-        "identifiers found among var `probe_ids`, `gene_ids`, or the var index."
-    )
-
-
-def subset_cellbender_to_filtered(adata, adata_cellbender):
-    adata_cellbender = adata_cellbender[adata.obs_names]
-    if adata.n_vars == adata_cellbender.n_vars:
-        return adata_cellbender
-
-    target_keys = var_alignment_keys(adata)
-    source_keys = var_alignment_keys(adata_cellbender)
-
-    source_positions = pd.Series(np.arange(adata_cellbender.n_vars), index=source_keys)
-    if not source_positions.index.is_unique:
-        source_positions = source_positions[~source_positions.index.duplicated(keep="first")]
-
-    positions = source_positions.loc[target_keys.values]
-    if positions.isna().any():
-        missing = target_keys[positions.isna()].unique()[:5]
-        raise ValueError(
-            "Features from the filtered matrix were not found in the CellBender output. "
-            f"Examples: {list(missing)}"
-        )
-
-    return adata_cellbender[:, positions.to_numpy(dtype=int)]
-
-
 adata = ad.read_h5ad("${filtered}")
 
 adata_cellbender = load_anndata_from_input_and_output("${unfiltered}", "${cellbender_h5}", analyzed_barcodes_only=False)
 
-adata_cellbender = subset_cellbender_to_filtered(adata, adata_cellbender)
+# Subset to the barcodes and genes present in the filtered matrix.
+# Gene symbols (var index) may not be unique, so align on Ensembl IDs.
+# The filtered h5ad uses 'gene_ids'; load_anndata_from_input_and_output uses 'gene_id'.
+gene_id_col = "gene_id" if "gene_id" in adata_cellbender.var.columns else adata_cellbender.var.index.name
+cb_id_to_pos = {gid: i for i, gid in enumerate(adata_cellbender.var[gene_id_col])}
+var_positions = [cb_id_to_pos[gid] for gid in adata.var["gene_ids"]]
+adata_cellbender = adata_cellbender[adata.obs_names, var_positions]
 
 if "${output_layer}" == "X":
     adata.X = adata_cellbender.layers["cellbender"]

--- a/modules/nf-core/cellbender/merge/templates/merge.py
+++ b/modules/nf-core/cellbender/merge/templates/merge.py
@@ -4,6 +4,8 @@ import platform
 
 import anndata as ad
 import cellbender
+import numpy as np
+import pandas as pd
 from cellbender.remove_background.downstream import load_anndata_from_input_and_output
 
 
@@ -25,11 +27,52 @@ def format_yaml_like(data: dict, indent: int = 0) -> str:
     return yaml_str
 
 
+def var_alignment_keys(adata):
+    if "probe_ids" in adata.var.columns:
+        keys = adata.var["probe_ids"].astype(str)
+        if keys.is_unique:
+            return keys
+    if "gene_ids" in adata.var.columns:
+        keys = adata.var["gene_ids"].astype(str)
+        if keys.is_unique:
+            return keys
+    keys = adata.var.index.astype(str)
+    if keys.is_unique:
+        return keys
+    raise ValueError(
+        "Cannot align CellBender output to the filtered matrix: no unique feature "
+        "identifiers found among var `probe_ids`, `gene_ids`, or the var index."
+    )
+
+
+def subset_cellbender_to_filtered(adata, adata_cellbender):
+    adata_cellbender = adata_cellbender[adata.obs_names]
+    if adata.n_vars == adata_cellbender.n_vars:
+        return adata_cellbender
+
+    target_keys = var_alignment_keys(adata)
+    source_keys = var_alignment_keys(adata_cellbender)
+
+    source_positions = pd.Series(np.arange(adata_cellbender.n_vars), index=source_keys)
+    if not source_positions.index.is_unique:
+        source_positions = source_positions[~source_positions.index.duplicated(keep="first")]
+
+    positions = source_positions.loc[target_keys.values]
+    if positions.isna().any():
+        missing = target_keys[positions.isna()].unique()[:5]
+        raise ValueError(
+            "Features from the filtered matrix were not found in the CellBender output. "
+            f"Examples: {list(missing)}"
+        )
+
+    return adata_cellbender[:, positions.to_numpy(dtype=int)]
+
+
 adata = ad.read_h5ad("${filtered}")
 
 adata_cellbender = load_anndata_from_input_and_output("${unfiltered}", "${cellbender_h5}", analyzed_barcodes_only=False)
 
-adata_cellbender = adata_cellbender[adata.obs_names, adata.var_names]
+adata_cellbender = subset_cellbender_to_filtered(adata, adata_cellbender)
 
 if "${output_layer}" == "X":
     adata.X = adata_cellbender.layers["cellbender"]


### PR DESCRIPTION
## Summary

- Fix `CELLBENDER_MERGE` failing on 10x Flex data where filtered and raw matrices have different gene sets (closes #289)
- Subset CellBender output to both filtered barcodes and genes before writing the ambient-corrected layer
- Formalize the change as an nf-core modules patch (`cellbender-merge.diff`) so it survives future module updates

## Test plan

- [x] `nft subworkflows/local/ambient_correction/tests/main.nf.test` — all 12 tests pass, including both cellbender cases; no snapshot changes
- [x] Manual validation on 10x Flex data with `ambient_correction = 'cellbender'`