### PR TITLE
Add --skip_qc_report parameter to skip Quarto report rendering

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -66,6 +66,7 @@ workflow NFCORE_SCDOWNSTREAM {
     expimap_gmt                   //   value: string
     skip_liana                    //   value: boolean
     skip_rankgenesgroups          //   value: boolean
+    skip_qc_report                //   value: boolean
     scib                          //   value: boolean
     scib_max_cells                //   value: integer or null
     scib_subsample_strategy       //   value: string
@@ -130,6 +131,7 @@ workflow NFCORE_SCDOWNSTREAM {
         expimap_gmt,
         skip_liana,
         skip_rankgenesgroups,
+        skip_qc_report,
         scib,
         scib_max_cells,
         scib_subsample_strategy,
@@ -236,6 +238,7 @@ workflow {
         params.expimap_gmt,
         params.skip_liana,
         params.skip_rankgenesgroups,
+        params.skip_qc_report,
         params.scib,
         params.scib_max_cells,
         params.scib_subsample_strategy,

--- a/nextflow.config
+++ b/nextflow.config
@@ -69,6 +69,7 @@ params {
     qc_only                       = false
     skip_liana                    = false
     skip_rankgenesgroups          = false
+    skip_qc_report                = false
     scib                          = false
     scib_max_cells                = null
     scib_subsample_strategy       = 'stratified_label_batch'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -348,6 +348,10 @@
                     "type": "boolean",
                     "description": "Skip the rank_genes_groups step. For large datasets, the pipeline might fail due to high memory usage in this step. Use this option to skip it."
                 },
+                "skip_qc_report": {
+                    "type": "boolean",
+                    "description": "Skip rendering the Quarto QC HTML report in reports/."
+                },
                 "scib": {
                     "type": "boolean",
                     "default": false,

--- a/workflows/scdownstream.nf
+++ b/workflows/scdownstream.nf
@@ -65,6 +65,7 @@ workflow SCDOWNSTREAM {
     expimap_gmt                   //   value: string
     skip_liana                    //   value: boolean
     skip_rankgenesgroups          //   value: boolean
+    skip_qc_report                //   value: boolean
     scib                          //   value: boolean
     scib_max_cells                //   value: integer or null
     scib_subsample_strategy       //   value: string
@@ -340,32 +341,34 @@ workflow SCDOWNSTREAM {
     //
     // Render quality control report
     //
-    qc_report_notebook = file("${projectDir}/bin/qc-report.qmd", checkIfExists: true)
-    extensions = channel.fromPath("${projectDir}/assets/_extensions").collect()
-    if (!qc_only) {
-        ch_qc_report_input_base = FINALIZE.out.h5ad
-    } else {
-        ch_qc_report_input_base = ch_h5ad
+    if (!skip_qc_report) {
+        qc_report_notebook = file("${projectDir}/bin/qc-report.qmd", checkIfExists: true)
+        extensions = channel.fromPath("${projectDir}/assets/_extensions").collect()
+        if (!qc_only) {
+            ch_qc_report_input_base = FINALIZE.out.h5ad
+        } else {
+            ch_qc_report_input_base = ch_h5ad
+        }
+        if (ch_input) {
+            ch_sizes = QUALITY_CONTROL.out.sizes.map { _meta, tsv -> tsv }
+        } else {
+            ch_sizes = channel.empty()
+        }
+        ch_qc_report_input_data = ch_qc_report_input_base
+            .map { _meta, h5ad -> h5ad }
+            .mix ( ch_sizes )
+            .collect()
+        qc_report_params = [
+            qc_only: qc_only,
+            has_input: ch_input != null
+        ]
+        QC_REPORT (
+            [[id: 'qc-report'], qc_report_notebook],
+            qc_report_params,
+            ch_qc_report_input_data,
+            extensions
+        )
     }
-    if (ch_input) {
-        ch_sizes = QUALITY_CONTROL.out.sizes.map { _meta, tsv -> tsv }
-    } else {
-        ch_sizes = channel.empty()
-    }
-    ch_qc_report_input_data = ch_qc_report_input_base
-        .map { _meta, h5ad -> h5ad }
-        .mix ( ch_sizes )
-        .collect()
-    qc_report_params = [
-        qc_only: qc_only,
-        has_input: ch_input != null
-    ]
-    QC_REPORT (
-        [[id: 'qc-report'], qc_report_notebook],
-        qc_report_params,
-        ch_qc_report_input_data,
-        extensions
-    )
 
     //
     // Collate and save software versions


### PR DESCRIPTION
## Summary
- Add a `--skip_qc_report` pipeline parameter (default: `false`) to optionally skip rendering the Quarto QC HTML report in `reports/`.
- Gate the `QC_REPORT` process in `SCDOWNSTREAM` so large runs can bypass the memory-heavy report step while keeping MultiQC and other pipeline outputs unchanged.

## Test plan
- [ ] Run the default test profile and confirm `reports/qc-report.html` is still produced
- [ ] Re-run with `--skip_qc_report` and confirm the pipeline completes without `reports/qc-report.html`
- [ ] Confirm MultiQC output is unchanged in both cases