### PR TITLE
Deprecate `quartonotebook` in favour of `quarto/notebook`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Initial release of nf-core/scdownstream, created with the [nf-core](https://nf-c
 
 ### `Changed`
 
+- Replace the deprecated `QUARTONOTEBOOK` module with `QUARTO_NOTEBOOK` for rendering the QC report.
 - Make final AnnData-to-RDS conversion (`ADATA_TORDS`) opt-in via `--tords` (previously always run).
 - Restructure `06_per_group` to a context-first hierarchy (`{integration}/{subset}/{leiden|label}/...`) and move former `07_pseudobulk_de` outputs under `06_per_group/.../differential_expression/`.
 - Prefix published result directories with numeric stage IDs (`01_load_h5ad` through `11_multiqc`) so lexical sort matches pipeline order; nest gene unification under `02_quality_control/unify`.

--- a/bin/qc-report.qmd
+++ b/bin/qc-report.qmd
@@ -27,7 +27,7 @@ from IPython.display import display, Markdown
 ```{python export-versions}
 pd.DataFrame({
     'package': ['pandas', 'scanpy', 'anndata'],
-    'version': [pd.__version__, matplotlib.__version__, sc.__version__, ad.__version__],
+    'version': [pd.__version__, sc.__version__, ad.__version__],
 }).to_csv('versions.csv', index=False, header=False)
 ```
 

--- a/bin/qc-report.qmd
+++ b/bin/qc-report.qmd
@@ -24,6 +24,13 @@ from textwrap import dedent
 from IPython.display import display, Markdown
 ```
 
+```{python export-versions}
+pd.DataFrame({
+    'package': ['pandas', 'scanpy', 'anndata'],
+    'version': [pd.__version__, matplotlib.__version__, sc.__version__, ad.__version__],
+}).to_csv('versions.csv', index=False, header=False)
+```
+
 ```{python common-functions}
 def rotate_x_labels(ax, label_size=8):
     """

--- a/modules.json
+++ b/modules.json
@@ -32,9 +32,9 @@
                         "git_sha": "cd0ad387832473916b1f1c80c2ca673a7883bf94",
                         "installed_by": ["modules"]
                     },
-                    "quartonotebook": {
+                    "quarto/notebook": {
                         "branch": "master",
-                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "git_sha": "b0c002b4eeaae7b0fa0181b098bb318269b11cf5",
                         "installed_by": ["modules"]
                     },
                     "scanpy/scrublet": {

--- a/modules/nf-core/quarto/notebook/environment.yml
+++ b/modules/nf-core/quarto/notebook/environment.yml
@@ -8,5 +8,7 @@ dependencies:
   - conda-forge::jupyter=1.1.1
   - conda-forge::matplotlib=3.10.3
   - conda-forge::papermill=2.6.0
+  - conda-forge::python=3.12.11
   - conda-forge::quarto=1.7.31
+  - conda-forge::r-base=4.4.3
   - conda-forge::r-rmarkdown=2.29

--- a/modules/nf-core/quarto/notebook/main.nf
+++ b/modules/nf-core/quarto/notebook/main.nf
@@ -1,9 +1,14 @@
-// NB: You'll likely want to override this with a container containing all
+// NB 1: You'll likely want to override this with a container containing all
 // required dependencies for your analyses. Or use wave to build the container
 // for you from the environment.yml You'll at least need Quarto itself,
 // Papermill and whatever language you are running your analyses on; you can see
 // an example in this module's environment file.
-process QUARTONOTEBOOK {
+//
+// NB 2: You'll need to export the versions of the packages you are using inside
+// your notebook to a `versions.csv` file (formatted as `package,version`),
+// which will be added to the `versions` topic; module versions are handled
+// separately by `eval()` statements.
+process QUARTO_NOTEBOOK {
     tag "${meta.id}"
     label 'process_low'
     conda "${moduleDir}/environment.yml"
@@ -23,7 +28,8 @@ process QUARTONOTEBOOK {
     tuple val(meta), path("params.yml")                                                        , emit: params_yaml
     tuple val(meta), path("${notebook_parameters.artifact_dir}/*")                             , emit: artifacts  , optional: true
     tuple val(meta), path("_extensions")                                                       , emit: extensions , optional: true
-    tuple val("${task.process}"), val('quarto'), eval('quarto -v'), emit: versions_quarto, topic: versions
+    path "versions.yml"                                                                        , emit: versions          , topic: versions
+    tuple val("${task.process}"), val('quarto'), eval('quarto -v')                             , emit: versions_quarto   , topic: versions
     tuple val("${task.process}"), val('papermill'), eval('papermill --version | cut -f1 -d" "'), emit: versions_papermill, topic: versions
 
     when:
@@ -78,6 +84,18 @@ process QUARTONOTEBOOK {
         ${args} \\
         --execute-params params.yml \\
         --output ${prefix}.html
+
+    # Check that notebook package versions is exported
+    if [ ! -f versions.csv ]; then
+        echo "ERROR: versions.csv not found; the notebook must write out [tool,version] pairs used within it." >&2
+        exit 1
+    fi
+
+    # Write notebook package versions to YAML
+    cat <<- END_VERSIONS > versions.yml
+    "${task.process}":
+    \$(awk -F',' '{printf "    %s: %s\\n", \$1, \$2}' versions.csv)
+    END_VERSIONS
     """
 
     stub:
@@ -100,5 +118,6 @@ process QUARTONOTEBOOK {
 
     touch ${prefix}.html
     touch params.yml
+    touch versions.yml
     """
 }

--- a/modules/nf-core/quarto/notebook/meta.yml
+++ b/modules/nf-core/quarto/notebook/meta.yml
@@ -1,4 +1,4 @@
-name: "quartonotebook"
+name: "quarto_notebook"
 description: Render a Quarto notebook, including parametrization.
 keywords:
   - quarto
@@ -7,21 +7,22 @@ keywords:
   - python
   - r
 tools:
-  - quartonotebook:
+  - quarto:
       description: An open-source scientific and technical publishing system.
       homepage: https://quarto.org/
       documentation: https://quarto.org/docs/reference/
       tool_dev_url: https://github.com/quarto-dev/quarto-cli
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
   - papermill:
       description: Parameterize, execute, and analyze notebooks
       homepage: https://github.com/nteract/papermill
       documentation: http://papermill.readthedocs.io/en/latest/
       tool_dev_url: https://github.com/nteract/papermill
-      licence: ["BSD 3-clause"]
+      licence:
+        - "BSD 3-clause"
       identifier: ""
-
 input:
   - - meta:
         type: map
@@ -70,8 +71,7 @@ output:
             e.g. `[ id:'sample1', single_end:false ]`.
       - notebook:
           type: file
-          description: The Quarto notebook that was rendered. Allows user to
-            continue working on the notebook.
+          description: The Quarto notebook that was rendered. Allows user to continue working on the notebook.
           pattern: "*.{qmd}"
           ontologies: []
   params_yaml:
@@ -107,6 +107,13 @@ output:
           description: Quarto extensions used during report rendering.
           pattern: "*"
           ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: Optional YAML file containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750
   versions_quarto:
     - - ${task.process}:
           type: string
@@ -127,9 +134,14 @@ output:
       - papermill --version | cut -f1 -d" ":
           type: eval
           description: The expression to obtain the version of the tool
-
 topics:
   versions:
+    - versions.yml:
+        type: file
+        description: Optional YAML file containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750
     - - ${task.process}:
           type: string
           description: The name of the process
@@ -148,7 +160,6 @@ topics:
       - papermill --version | cut -f1 -d" ":
           type: eval
           description: The expression to obtain the version of the tool
-
 authors:
   - "@fasterius"
 maintainers:

--- a/modules/nf-core/quarto/notebook/tests/main.nf.test
+++ b/modules/nf-core/quarto/notebook/tests/main.nf.test
@@ -1,12 +1,14 @@
 nextflow_process {
 
-    name "Test Process QUARTONOTEBOOK"
+    name "Test Process QUARTO_NOTEBOOK"
     script "../main.nf"
-    process "QUARTONOTEBOOK"
+    process "QUARTO_NOTEBOOK"
+    config "./nextflow.config"
 
     tag "modules"
     tag "modules_nfcore"
-    tag "quartonotebook"
+    tag "quarto"
+    tag "quarto/notebook"
 
     test("test notebook - [qmd:r]") {
 
@@ -164,6 +166,13 @@ nextflow_process {
     test("test notebook - parametrized - [ipynb]") {
 
         when {
+            params {
+                // The Jupyter Notebook test need to explicitly execute the code
+                // in the notebook instead of just rendering the notebook to
+                // HTML (which is the default), in order to correctly output
+                // `versions.csv`.
+                module_args = '--execute'
+            }
             process {
                 """
                 input[0] = [

--- a/modules/nf-core/quarto/notebook/tests/main.nf.test.snap
+++ b/modules/nf-core/quarto/notebook/tests/main.nf.test.snap
@@ -15,7 +15,7 @@
                         {
                             "id": "test"
                         },
-                        "quarto_r.qmd:md5,b3fa8b456efae62495c0b278a4f7694c"
+                        "quarto_r.qmd:md5,a6a7392a32a4a2f5637fd8245b936031"
                     ]
                 ],
                 "2": [
@@ -33,15 +33,18 @@
                     
                 ],
                 "5": [
+                    "versions.yml:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ],
+                "6": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "quarto",
                         "1.7.31"
                     ]
                 ],
-                "6": [
+                "7": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "papermill",
                         "2.6.0"
                     ]
@@ -65,7 +68,7 @@
                         {
                             "id": "test"
                         },
-                        "quarto_r.qmd:md5,b3fa8b456efae62495c0b278a4f7694c"
+                        "quarto_r.qmd:md5,a6a7392a32a4a2f5637fd8245b936031"
                     ]
                 ],
                 "params_yaml": [
@@ -76,41 +79,47 @@
                         "params.yml:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "versions": [
+                    "versions.yml:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ],
                 "versions_papermill": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "papermill",
                         "2.6.0"
                     ]
                 ],
                 "versions_quarto": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "quarto",
                         "1.7.31"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-08-18T09:19:47.986553",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-01-27T09:38:07.013617"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
     "test notebook - [qmd:r]": {
         "content": [
             {
+                "versions": [
+                    "versions.yml:md5,ffbc211e9dcc1252c411bdd2f072b92e"
+                ],
                 "versions_papermill": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "papermill",
                         "2.6.0"
                     ]
                 ],
                 "versions_quarto": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "quarto",
                         "1.7.31"
                     ]
@@ -129,29 +138,32 @@
                     {
                         "id": "test"
                     },
-                    "params.yml:md5,8b9e438c0eb4850e20035a1222cd151e"
+                    "params.yml:md5,6d2ec3cf3e2f15958ab8ab440d651f8d"
                 ]
             ]
         ],
+        "timestamp": "2026-08-18T15:12:25.10271",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-01-27T09:36:34.251547"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
     "test notebook - parametrized - [qmd:python]": {
         "content": [
             {
+                "versions": [
+                    "versions.yml:md5,68fd39542815eb5537cdb4b234e2d30d"
+                ],
                 "versions_papermill": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "papermill",
                         "2.6.0"
                     ]
                 ],
                 "versions_quarto": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "quarto",
                         "1.7.31"
                     ]
@@ -170,29 +182,32 @@
                     {
                         "id": "test"
                     },
-                    "params.yml:md5,0dbcd58276179f0700e144e45d8d3c76"
+                    "params.yml:md5,4fd353560b2c3366515af2cc4d49957d"
                 ]
             ]
         ],
+        "timestamp": "2026-08-18T15:13:37.473159",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-01-27T09:42:32.224154"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
     "test notebook - parametrized - [rmd]": {
         "content": [
             {
+                "versions": [
+                    "versions.yml:md5,ffbc211e9dcc1252c411bdd2f072b92e"
+                ],
                 "versions_papermill": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "papermill",
                         "2.6.0"
                     ]
                 ],
                 "versions_quarto": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "quarto",
                         "1.7.31"
                     ]
@@ -211,65 +226,32 @@
                     {
                         "id": "test"
                     },
-                    "params.yml:md5,0dbcd58276179f0700e144e45d8d3c76"
+                    "params.yml:md5,4fd353560b2c3366515af2cc4d49957d"
                 ]
             ]
         ],
+        "timestamp": "2026-08-18T15:13:53.297883",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-01-27T09:37:47.267654"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
     "test notebook - parametrized - [ipynb]": {
         "content": [
             {
+                "versions": [
+                    "versions.yml:md5,68fd39542815eb5537cdb4b234e2d30d"
+                ],
                 "versions_papermill": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "papermill",
                         "2.6.0"
                     ]
                 ],
                 "versions_quarto": [
                     [
-                        "QUARTONOTEBOOK",
-                        "quarto",
-                        "1.7.31"
-                    ]
-                ]
-            },
-            [
-                
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "params.yml:md5,0dbcd58276179f0700e144e45d8d3c76"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-01-27T09:38:02.01495"
-    },
-    "test notebook - [qmd:python]": {
-        "content": [
-            {
-                "versions_papermill": [
-                    [
-                        "QUARTONOTEBOOK",
-                        "papermill",
-                        "2.6.0"
-                    ]
-                ],
-                "versions_quarto": [
-                    [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "quarto",
                         "1.7.31"
                     ]
@@ -288,29 +270,76 @@
                     {
                         "id": "test"
                     },
-                    "params.yml:md5,8b9e438c0eb4850e20035a1222cd151e"
+                    "params.yml:md5,4fd353560b2c3366515af2cc4d49957d"
                 ]
             ]
         ],
+        "timestamp": "2026-08-18T15:14:10.605053",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-01-27T09:36:54.331697"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
-    "test notebook - parametrized - [qmd:r]": {
+    "test notebook - [qmd:python]": {
         "content": [
             {
+                "versions": [
+                    "versions.yml:md5,68fd39542815eb5537cdb4b234e2d30d"
+                ],
                 "versions_papermill": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
                         "papermill",
                         "2.6.0"
                     ]
                 ],
                 "versions_quarto": [
                     [
-                        "QUARTONOTEBOOK",
+                        "QUARTO_NOTEBOOK",
+                        "quarto",
+                        "1.7.31"
+                    ]
+                ]
+            },
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "artifact.txt:md5,8ddd8be4b179a529afa5f2ffae4b9858"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "params.yml:md5,6d2ec3cf3e2f15958ab8ab440d651f8d"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-18T15:12:45.306028",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "test notebook - parametrized - [qmd:r]": {
+        "content": [
+            {
+                "versions": [
+                    "versions.yml:md5,ffbc211e9dcc1252c411bdd2f072b92e"
+                ],
+                "versions_papermill": [
+                    [
+                        "QUARTO_NOTEBOOK",
+                        "papermill",
+                        "2.6.0"
+                    ]
+                ],
+                "versions_quarto": [
+                    [
+                        "QUARTO_NOTEBOOK",
                         "quarto",
                         "1.7.31"
                     ]
@@ -329,14 +358,14 @@
                     {
                         "id": "test"
                     },
-                    "params.yml:md5,0dbcd58276179f0700e144e45d8d3c76"
+                    "params.yml:md5,4fd353560b2c3366515af2cc4d49957d"
                 ]
             ]
         ],
+        "timestamp": "2026-08-18T15:13:18.571016",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-01-27T09:37:12.792978"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     }
 }

--- a/modules/nf-core/quarto/notebook/tests/nextflow.config
+++ b/modules/nf-core/quarto/notebook/tests/nextflow.config
@@ -1,0 +1,18 @@
+// Initialise `module_args` parameter
+params {
+    module_args = null
+}
+
+process {
+    withName: QUARTO_NOTEBOOK {
+
+        // Enable per-test parameters
+        ext.args = { params.module_args ?: '' }
+
+        // Pinned: `task.cpus` is embedded in `params.yml` and included in the
+        // rendered output, so leaving it unset breaks snapshot reproducibility
+        // across machines.
+        cpus = 1
+
+    }
+}

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -274,14 +274,14 @@
                 "nf-core.theme:md5,ac9559ae18b3f513cf7a5419e4a69c24",
                 "toc.html:md5,fe6831ffaecfb53058310943d42942ca",
                 "params.yml:md5,1b2f06e328f9635998c2401a89c501ec",
-                "qc-report.qmd:md5,13061014a897b3fbdafd6ea3212df0e0",
+                "qc-report.qmd:md5,51377910e991febdc984a72808a261c0",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-08-09T20:52:48.961739203",
+        "timestamp": "2026-08-31T14:48:48.167781689",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/main_pipeline_build.nf.test.snap
+++ b/tests/main_pipeline_build.nf.test.snap
@@ -278,14 +278,14 @@
                 "nf-core.theme:md5,ac9559ae18b3f513cf7a5419e4a69c24",
                 "toc.html:md5,fe6831ffaecfb53058310943d42942ca",
                 "params.yml:md5,1b2f06e328f9635998c2401a89c501ec",
-                "qc-report.qmd:md5,13061014a897b3fbdafd6ea3212df0e0",
+                "qc-report.qmd:md5,51377910e991febdc984a72808a261c0",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-08-09T20:53:28.654156185",
+        "timestamp": "2026-08-31T14:51:26.994216253",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/main_pipeline_extend.nf.test.snap
+++ b/tests/main_pipeline_extend.nf.test.snap
@@ -225,14 +225,14 @@
                 "nf-core.theme:md5,ac9559ae18b3f513cf7a5419e4a69c24",
                 "toc.html:md5,fe6831ffaecfb53058310943d42942ca",
                 "params.yml:md5,1b2f06e328f9635998c2401a89c501ec",
-                "qc-report.qmd:md5,13061014a897b3fbdafd6ea3212df0e0",
+                "qc-report.qmd:md5,51377910e991febdc984a72808a261c0",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-08-09T20:43:55.660131861",
+        "timestamp": "2026-08-31T14:41:59.551688144",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/main_pipeline_qc.nf.test.snap
+++ b/tests/main_pipeline_qc.nf.test.snap
@@ -172,14 +172,14 @@
                 "nf-core.theme:md5,ac9559ae18b3f513cf7a5419e4a69c24",
                 "toc.html:md5,fe6831ffaecfb53058310943d42942ca",
                 "params.yml:md5,cd7fb3f941b1b5ad10a8e413ad70623c",
-                "qc-report.qmd:md5,13061014a897b3fbdafd6ea3212df0e0",
+                "qc-report.qmd:md5,51377910e991febdc984a72808a261c0",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-08-09T20:40:35.402651817",
+        "timestamp": "2026-08-31T14:43:04.261914379",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/main_pipeline_reference_mapping.nf.test.snap
+++ b/tests/main_pipeline_reference_mapping.nf.test.snap
@@ -223,14 +223,14 @@
                 "nf-core.theme:md5,ac9559ae18b3f513cf7a5419e4a69c24",
                 "toc.html:md5,fe6831ffaecfb53058310943d42942ca",
                 "params.yml:md5,1b2f06e328f9635998c2401a89c501ec",
-                "qc-report.qmd:md5,13061014a897b3fbdafd6ea3212df0e0",
+                "qc-report.qmd:md5,51377910e991febdc984a72808a261c0",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-08-09T20:44:54.963904303",
+        "timestamp": "2026-08-31T14:43:23.47603857",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/main_pipeline_sub.nf.test.snap
+++ b/tests/main_pipeline_sub.nf.test.snap
@@ -102,14 +102,14 @@
                 "nf-core.theme:md5,ac9559ae18b3f513cf7a5419e4a69c24",
                 "toc.html:md5,fe6831ffaecfb53058310943d42942ca",
                 "params.yml:md5,dba27060f41cac7c739000e07a760569",
-                "qc-report.qmd:md5,13061014a897b3fbdafd6ea3212df0e0",
+                "qc-report.qmd:md5,51377910e991febdc984a72808a261c0",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-08-09T20:44:42.629094025",
+        "timestamp": "2026-08-31T14:52:03.838404833",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/tests/main_pipeline_sub_integrate_per_label.nf.test.snap
+++ b/tests/main_pipeline_sub_integrate_per_label.nf.test.snap
@@ -77,14 +77,14 @@
                 "nf-core.theme:md5,ac9559ae18b3f513cf7a5419e4a69c24",
                 "toc.html:md5,fe6831ffaecfb53058310943d42942ca",
                 "params.yml:md5,dba27060f41cac7c739000e07a760569",
-                "qc-report.qmd:md5,13061014a897b3fbdafd6ea3212df0e0",
+                "qc-report.qmd:md5,51377910e991febdc984a72808a261c0",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-08-09T20:54:38.643250111",
+        "timestamp": "2026-08-31T14:32:47.179005174",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
         }
     }
 }

--- a/workflows/scdownstream.nf
+++ b/workflows/scdownstream.nf
@@ -8,7 +8,7 @@ include { LOAD_H5AD                            } from '../subworkflows/local/loa
 include { QUALITY_CONTROL                      } from '../subworkflows/local/quality_control'
 include { PER_CELL_ANNOTATION                  } from '../subworkflows/local/per_cell_annotation'
 include { ADATA_EXTEND as FINALIZE_QC_ANNDATAS } from '../modules/local/adata/extend'
-include { QUARTONOTEBOOK as QC_REPORT          } from '../modules/nf-core/quartonotebook'
+include { QUARTO_NOTEBOOK as QC_REPORT         } from '../modules/nf-core/quarto/notebook'
 include { COMBINE                              } from '../subworkflows/local/combine'
 include { ADATA_SPLITEMBEDDINGS                } from '../modules/local/adata/splitembeddings'
 include { SUB_INTEGRATE                        } from '../subworkflows/local/sub_integrate'


### PR DESCRIPTION
This PR removes the deprecated `quartonotebook` module in favour of the new `quarto/notebook`, which works identically to the former, with the addition of a `versions.csv` output requirement (just a CSV with `package,version`), to properly track notebook software versions.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] `CHANGELOG.md` is updated.
