### PR TITLE
Add `manifest.diagram` to `nextflow.config`

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -378,6 +378,7 @@ manifest {
     nextflowVersion = '!>=25.10.4'
     version         = '0.0.1dev'
     doi             = ''
+    diagram         = 'docs/images/metromap.svg'
 }
 
 // Nextflow plugins


### PR DESCRIPTION
Adds the new `manifest.diagram` config attribute, pointing at the pipeline overview diagram.

See nf-core/tools#4460 for background: `manifest.diagram` gives a canonical location for the metro map, so that downstream consumers can find it. We'll use it for the nf-core website soon, for example. The new config option won't be released until Nextflow `26.10`, but older versions ignore unknown manifest fields, so it's safe to set in any pipeline today.